### PR TITLE
feat(pages): add GitHub Pages viewer build and deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,47 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install
+        run: npm ci
+
+      - name: Build Pages
+        run: npm run pages:build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist-pages
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ yarn-error.log*
 dist/
 build/
 coverage/
+dist-pages/
 
 # Environment files
 .env

--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@ bun server.ts
 
 http://localhost:3000/ にアクセスして、コンポーネントビューアが表示されます。
 
+## 🌐 GitHub Pages での公開（Project Pages）
+
+`viewer.html` を静的化して `dist-pages/` に出力し、GitHub Pages で表示できます（`dist-pages/` はコミットせず、CIで生成してデプロイします）。
+
+```bash
+# 静的ファイル生成
+npm run pages:build
+
+# ローカルプレビュー（デフォルト: http://localhost:3001/）
+npm run pages:preview
+```
+
+- デプロイは `.github/workflows/pages.yml` で main push をトリガーに実行されます
+- GitHub のリポジトリ設定で Pages の Source を **GitHub Actions** に設定してください
+
 ## 📦 利用可能なコンポーネント
 
 ### Component Viewer (`viewer.html`)

--- a/docs/plans/gh-pages-viewer.md
+++ b/docs/plans/gh-pages-viewer.md
@@ -1,0 +1,156 @@
+# GitHub Pages で `viewer.html` を静的公開する計画（Project Pages）
+
+## 目的
+
+`bun server.ts` で表示できているコンポーネントビューア（`viewer.html`）を、GitHub Pages（Project Pages: `/<repo>/` 配下）でも同等に表示できるようにする。
+
+## 背景（現状整理）
+
+- ローカルでは `server.ts` が以下を担っている
+  - `/` → `viewer.html` を返す
+  - `/core/*`・`/utils/*`・`/styles/*`・`/components/*`・`/@components/*` を `packages/*` にマッピング
+  - `.ts` をオンザフライでトランスパイルして `.js` として配信
+- GitHub Pages は静的ホスティングのため、上記を「事前ビルド（静的ファイル生成）」に置き換える必要がある
+
+## レビュー結果（設計上の前提が成立するか）
+
+### ✅ 内部 import の書き方
+
+- `packages/**` の内部 import は「相対パス + `.js` 拡張子」で統一されている
+  - 例: `../../core/web-components.js`, `../../components/button/index.js`
+- そのため、**出力ディレクトリ構造を正しく作れば**、トランスパイル後も import パスの書き換えは不要
+
+### ✅ 追加で書き換える必要があるのは HTML（と HTML 内の文字列）だけ
+
+- `viewer.html` 内では以下が先頭 `/` の絶対パスになっている
+  - import map の value
+  - `<link rel="modulepreload" href="...">`
+  - `navigator.serviceWorker.register('/sw.js')`
+  - `import('/@components/...')` などの dynamic import 文字列
+- Project Pages（`/<repo>/`）で動かすため、これらは `./` 始まりの相対パスに寄せる
+
+## 要件（Acceptance Criteria）
+
+- GitHub Pages で `index.html`（= `viewer.html` 相当）が表示される
+- `?component=...` の切り替えが動作する
+- Autoloader によるロードが動作し、各コンポーネントが表示される
+- 404 が発生しない（少なくとも以下）
+  - `core/*.js`, `utils/*.js`, `styles/*.js`, `components/**`, `@components/**`, `config.js`, `src/demos.js`
+- 初回は Service Worker を無効化してもよい（= SW 起因の 404 を避ける）
+
+## 方針（決定事項）
+
+- 出力先は `dist-pages/` に固定する（GitHub Pages artifact としてアップロード）
+- `.ts` → `.js` のトランスパイルは Node.js 上で TypeScript の `transpileModule` を使う（追加のビルド依存を増やさない）
+- 依存モジュールの import 文は原則変更しない（相対パス + `.js` を信頼する）
+- `viewer.html` のみ、絶対パスを相対パスに置換する
+- Service Worker はフェーズ1では無効（フェーズ2で scope 対応を入れてから有効化）
+
+## 生成物（`dist-pages/` の構造）
+
+```
+dist-pages/
+├── index.html
+├── config.js
+├── core/
+│   ├── web-components.js
+│   ├── autoloader.js
+│   └── preloader.js
+├── utils/
+│   └── *.js
+├── styles/
+│   └── *.js
+├── components/
+│   └── **/*.js
+├── @components/
+│   ├── dads/
+│   │   └── **/*.js
+│   └── meta/
+│       └── **/*.js
+└── src/
+    └── demos.js
+```
+
+## 実装ステップ（フェーズ1: “まず動かす”）
+
+### 1) ビルドスクリプト追加
+
+- `scripts/build-pages.cjs` を追加し、`dist-pages/` を生成する
+- 処理内容（概要）
+  1. `dist-pages/` をクリーン（削除→作り直し）
+  2. `viewer.html` → `dist-pages/index.html` にコピーし、パスを書き換える
+  3. `packages/**` / `src/demos.ts` をトランスパイルして `dist-pages/` に配置する
+
+### 2) `viewer.html` → `index.html` の書き換えルール
+
+- import map の value
+  - `"/@components/...` → `"./@components/...`
+  - `"/core/...` → `"./core/...`
+  - `"/core/autoloader.js"`（例: `@core/autoloader`）も同様に相対化する
+  - `"/src/demos.js"` → `"./src/demos.js"`
+- `modulepreload` の `href`
+  - `href="/core/...` → `href="./core/...`（他も同様）
+- `criticalComponents` / `componentAdapters` の文字列（dynamic import 用）
+  - `'/@components/...` → `'./@components/...`
+- Service Worker 登録ブロック
+  - フェーズ1では削除 or コメントアウト（`sw.js` は出力しない）
+
+### 3) トランスパイル対象と配置マッピング
+
+- `packages/config.ts` → `dist-pages/config.js`
+- `packages/core/**/*.ts` → `dist-pages/core/**/*.js`
+- `packages/utils/**/*.ts` → `dist-pages/utils/**/*.js`
+- `packages/styles/**/*.ts` → `dist-pages/styles/**/*.js`
+- `packages/components/**/*.ts` → `dist-pages/components/**/*.js`
+- `packages/autoload/dads/**/*.ts` → `dist-pages/@components/dads/**/*.js`
+- `packages/autoload/meta/**/*.ts` → `dist-pages/@components/meta/**/*.js`
+- `src/demos.ts` → `dist-pages/src/demos.js`
+
+#### 除外（トランスパイルしない）
+
+- `**/*.d.ts`（型定義）
+- `**/*.test.ts`（テスト）
+- `**/*.stories.ts`（Storybook）
+
+### 4) npm scripts 追加
+
+- `pages:build`（例: `npm run pages:build`）
+- （任意）`pages:preview`（例: `npm run pages:preview`。ポートは `PAGES_PORT` または `PORT` で上書き可能）
+
+### 5) `.gitignore` 追加
+
+```
+dist-pages/
+```
+
+### 6) GitHub Actions（Pages デプロイ）
+
+- `.github/workflows/pages.yml` を追加（main push でデプロイ）
+- 概要
+  - checkout
+  - permissions（`contents: read`, `pages: write`, `id-token: write`）
+  - Node.js setup & install（`npm ci`）
+  - `npm run pages:build`
+  - `actions/upload-pages-artifact`（`dist-pages/`）
+  - `actions/deploy-pages`
+
+### 7) 動作確認
+
+- ローカル
+  - `pages:build` 実行
+  - `dist-pages/` を静的サーブして確認（`index.html` が開ける / Network 404 がない）
+- GitHub Pages
+  - `https://<user>.github.io/<repo>/?component=button` などで表示確認
+
+## 懸念点と対策
+
+- **絶対パスが残っていると Project Pages で 404**
+  - 対策: `index.html` 生成時に、import map / preload / dynamic import 文字列を確実に `./` に統一
+- **Service Worker が absolute path をキャッシュしようとして 404**
+  - 対策: フェーズ1では SW を無効化してリスクを切り離す
+
+## フェーズ2（SW 有効化 / パフォーマンス最適化）
+
+- `sw.js` を `dist-pages/sw.js` に出力し、scope 対応に修正する
+  - `cache.addAll(['/core/...'])` のような絶対パスをやめる（`new URL('core/web-components.js', self.location)` など）
+  - `navigator.serviceWorker.register('./sw.js')` のように相対登録へ変更

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "pages:build": "node scripts/build-pages.cjs",
+    "pages:preview": "node scripts/preview-pages.cjs",
     "test": "vitest",
     "test:watch": "vitest --watch",
     "test:ui": "vitest --ui",

--- a/scripts/build-pages.cjs
+++ b/scripts/build-pages.cjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const ts = require('typescript');
+
+const projectRoot = process.cwd();
+const outDir = path.join(projectRoot, 'dist-pages');
+
+const compilerOptions = {
+  target: ts.ScriptTarget.ES2020,
+  module: ts.ModuleKind.ES2020,
+  strict: true,
+  sourceMap: false,
+  inlineSources: false,
+};
+
+function shouldTranspileTsFile(filePath) {
+  if (!filePath.endsWith('.ts')) return false;
+  if (filePath.endsWith('.d.ts')) return false;
+  if (filePath.endsWith('.test.ts')) return false;
+  if (filePath.endsWith('.stories.ts')) return false;
+  return true;
+}
+
+async function ensureDir(dirPath) {
+  await fs.mkdir(dirPath, { recursive: true });
+}
+
+async function collectFiles(dirPath) {
+  const entries = await fs.readdir(dirPath, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectFiles(entryPath)));
+      continue;
+    }
+    if (entry.isFile()) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+function transpileTsToJs(content, fileName) {
+  const result = ts.transpileModule(content, {
+    compilerOptions,
+    fileName,
+    reportDiagnostics: true,
+  });
+
+  if (result.diagnostics?.length) {
+    const formatted = ts.formatDiagnosticsWithColorAndContext(result.diagnostics, {
+      getCanonicalFileName: (p) => p,
+      getCurrentDirectory: () => projectRoot,
+      getNewLine: () => '\n',
+    });
+    throw new Error(`TypeScript transpile error in ${fileName}\n${formatted}`);
+  }
+
+  return result.outputText;
+}
+
+async function transpileFile(srcPath, destPath) {
+  const content = await fs.readFile(srcPath, 'utf8');
+  const js = transpileTsToJs(content, srcPath);
+  await ensureDir(path.dirname(destPath));
+  await fs.writeFile(destPath, js, 'utf8');
+}
+
+async function transpileTree(srcRoot, destRoot) {
+  const allFiles = await collectFiles(srcRoot);
+  const tsFiles = allFiles.filter((p) => shouldTranspileTsFile(p));
+
+  for (const srcPath of tsFiles) {
+    const relPath = path.relative(srcRoot, srcPath);
+    const destPath = path.join(destRoot, relPath).replace(/\.ts$/, '.js');
+    await transpileFile(srcPath, destPath);
+  }
+}
+
+function rewriteImportMapToRelative(html) {
+  const re = /<script\s+type="importmap">\s*([\s\S]*?)\s*<\/script>/;
+  const match = html.match(re);
+  if (!match) {
+    throw new Error('Import map not found in viewer.html');
+  }
+
+  const importMapJson = match[1];
+  const parsed = JSON.parse(importMapJson);
+  const imports = parsed.imports ?? {};
+
+  for (const [key, value] of Object.entries(imports)) {
+    if (typeof value !== 'string') continue;
+    if (value.startsWith('/')) {
+      imports[key] = `.${value}`; // "/x" -> "./x"
+    }
+  }
+
+  const rewritten = JSON.stringify({ ...parsed, imports }, null, 2);
+  return html.replace(re, `<script type="importmap">\n${rewritten}\n</script>`);
+}
+
+function removeServiceWorkerRegistration(html) {
+  const byComment =
+    /<!--\s*Service Worker登録（キャッシュ戦略）\s*-->\s*<script>[\s\S]*?<\/script>\s*/;
+  if (byComment.test(html)) {
+    return html.replace(byComment, '');
+  }
+
+  const byRegister = /<script>[\s\S]*?serviceWorker\.register\([\s\S]*?<\/script>\s*/;
+  if (byRegister.test(html)) {
+    return html.replace(byRegister, '');
+  }
+
+  return html;
+}
+
+function rewriteAbsoluteAssetPathsToRelative(html) {
+  // modulepreload, etc.
+  let out = html.replace(/href="\/([^"]+)"/g, 'href="./$1"');
+
+  // Dynamic import / preload arrays with leading "/@components/..."
+  out = out.replace(/(['"])\/@components\//g, '$1./@components/');
+
+  return out;
+}
+
+async function buildIndexHtml() {
+  const srcHtmlPath = path.join(projectRoot, 'viewer.html');
+  const srcHtml = await fs.readFile(srcHtmlPath, 'utf8');
+
+  let html = srcHtml;
+  html = removeServiceWorkerRegistration(html);
+  html = rewriteImportMapToRelative(html);
+  html = rewriteAbsoluteAssetPathsToRelative(html);
+
+  const destHtmlPath = path.join(outDir, 'index.html');
+  await ensureDir(outDir);
+  await fs.writeFile(destHtmlPath, html, 'utf8');
+}
+
+async function cleanOutDir() {
+  await fs.rm(outDir, { recursive: true, force: true });
+  await ensureDir(outDir);
+}
+
+async function main() {
+  console.log('[pages] Building GitHub Pages output...');
+
+  await cleanOutDir();
+  await buildIndexHtml();
+
+  await transpileFile(path.join(projectRoot, 'packages/config.ts'), path.join(outDir, 'config.js'));
+
+  await transpileTree(path.join(projectRoot, 'packages/core'), path.join(outDir, 'core'));
+  await transpileTree(path.join(projectRoot, 'packages/utils'), path.join(outDir, 'utils'));
+  await transpileTree(path.join(projectRoot, 'packages/styles'), path.join(outDir, 'styles'));
+  await transpileTree(path.join(projectRoot, 'packages/components'), path.join(outDir, 'components'));
+
+  await transpileTree(
+    path.join(projectRoot, 'packages/autoload/dads'),
+    path.join(outDir, '@components/dads')
+  );
+  await transpileTree(
+    path.join(projectRoot, 'packages/autoload/meta'),
+    path.join(outDir, '@components/meta')
+  );
+
+  await transpileFile(path.join(projectRoot, 'src/demos.ts'), path.join(outDir, 'src/demos.js'));
+
+  console.log('[pages] Done: dist-pages/');
+}
+
+main().catch((error) => {
+  console.error('[pages] Build failed:', error);
+  process.exitCode = 1;
+});
+

--- a/scripts/preview-pages.cjs
+++ b/scripts/preview-pages.cjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+const http = require('node:http');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const projectRoot = process.cwd();
+const rootDir = path.join(projectRoot, 'dist-pages');
+
+const port = Number.parseInt(process.env.PAGES_PORT ?? process.env.PORT ?? '3001', 10);
+
+const contentTypes = new Map([
+  ['.html', 'text/html; charset=utf-8'],
+  ['.js', 'application/javascript; charset=utf-8'],
+  ['.css', 'text/css; charset=utf-8'],
+  ['.json', 'application/json; charset=utf-8'],
+  ['.svg', 'image/svg+xml'],
+  ['.png', 'image/png'],
+  ['.jpg', 'image/jpeg'],
+  ['.jpeg', 'image/jpeg'],
+  ['.gif', 'image/gif'],
+  ['.woff', 'font/woff'],
+  ['.woff2', 'font/woff2'],
+  ['.ttf', 'font/ttf'],
+]);
+
+function safeJoin(root, requestPath) {
+  const normalized = requestPath.replace(/\\/g, '/');
+  const withoutQuery = normalized.split('?')[0].split('#')[0];
+  const decoded = decodeURIComponent(withoutQuery);
+  const cleaned = decoded.startsWith('/') ? decoded.slice(1) : decoded;
+  const joined = path.join(root, cleaned);
+
+  // Prevent path traversal
+  const rel = path.relative(root, joined);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    return null;
+  }
+  return joined;
+}
+
+async function fileExists(filePath) {
+  try {
+    const st = await fs.stat(filePath);
+    return st.isFile();
+  } catch {
+    return false;
+  }
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    if (!req.url) {
+      res.writeHead(400);
+      res.end('Bad Request');
+      return;
+    }
+
+    const url = new URL(req.url, 'http://localhost');
+    const pathname = url.pathname === '/' ? '/index.html' : url.pathname;
+    const filePath = safeJoin(rootDir, pathname);
+    if (!filePath) {
+      res.writeHead(403);
+      res.end('Forbidden');
+      return;
+    }
+
+    if (!(await fileExists(filePath))) {
+      res.writeHead(404);
+      res.end('Not Found');
+      return;
+    }
+
+    const ext = path.extname(filePath).toLowerCase();
+    const contentType = contentTypes.get(ext) ?? 'application/octet-stream';
+
+    const body = await fs.readFile(filePath);
+    res.writeHead(200, {
+      'Content-Type': contentType,
+      'Cache-Control': 'no-cache',
+    });
+    res.end(body);
+  } catch (error) {
+    res.writeHead(500);
+    res.end('Internal Server Error');
+    console.error('[pages:preview] Error:', error);
+  }
+});
+
+server.listen(port, async () => {
+  const indexUrl = pathToFileURL(path.join(rootDir, 'index.html')).href;
+  console.log(`[pages:preview] Serving ${rootDir}`);
+  console.log(`[pages:preview] http://localhost:${port}/`);
+  console.log(`[pages:preview] (local file) ${indexUrl}`);
+});
+


### PR DESCRIPTION
Adds Node-based Pages build (npm run pages:build) that generates dist-pages/ by rewriting viewer.html paths and transpiling TS modules to JS. Adds a local preview server (npm run pages:preview) with configurable port via PAGES_PORT/PORT. Deploys dist-pages/ to GitHub Pages via Actions (Node 20 + npm ci) on main pushes. Documents the CI-generated deploy/no-commit policy for dist-pages/.