### PR TITLE
Add dads-select and align form text sizes

### DIFF
--- a/.codex/plans/2026-01-17--feature-select.md
+++ b/.codex/plans/2026-01-17--feature-select.md
@@ -1,0 +1,87 @@
+# DADS セレクトボックス（`dads-select`）実装
+
+## 目標
+- DADS（HTML版 `select.css`）に準拠したセレクトボックスを Web Components として追加する
+- `viewer.html` で既存コンポーネント同等以上のデモ/操作感（エラー・必須・無効・サイズ）を確認できる状態にする
+
+## 背景
+- 現状 `packages/components/` に Select が未実装
+- 公式の参照元として、DADS HTML版の `select.css`/サンプルHTML、および React版の `aria-disabled` 運用（推奨）を確認済み
+
+## スコープ
+- やること：
+  - `dads-select` コンポーネント本体（DOM/スタイル/トークン/フォーム参加/バリデーション）
+  - `packages/autoload/dads/select.ts`（autoloadアダプター）
+  - `viewer.html` の importmap/セレクタ/プリロード、`src/demos.ts` のデモ追加
+  - Storybook ストーリー、Vitest テスト追加
+- やらないこと：
+  - 独自ドロップダウン（非ネイティブ）実装、検索可能select、multi-select対応
+  - `dads-form-control-label` 相当の別コンポーネント新設（今回は `dads-select` 内で label/support/error を扱う方針）
+
+## 前提 / 制約
+- `<dads-select>…<option>…</option></dads-select>` のように light DOM に置かれた `option/optgroup` を内部 `<select>` に複製する
+  - Shadow DOM の slot を `<select>` 直下に置いても options として解釈されない可能性が高いため
+- 見た目は DADS HTML版 `select.css` をベースに `::part()` 前提で移植する（色/角丸/hover/focus/error/forced-colors）
+- 無効化は DADS React の説明に合わせ、`disabled` と `aria-disabled` を両対応する：
+  - `disabled`: ネイティブ disabled（フォーカス不可・送信除外の通常挙動）
+  - `aria-disabled`: 見た目は無効＋操作を抑止（Tab移動は許容）＝「readonly相当」の挙動に寄せる
+
+## 変更内容（案）
+### データ / バックエンド
+- 該当なし
+
+### UI / UX
+- 新規コンポーネント `dads-select`
+  - label/support/error の slot + 属性フォールバック（既存 `dads-input-text`/`dads-textarea` と同等）
+  - `<select>` + chevron SVG の構造（DADS `select.css` と同等のスタイル）
+  - `size="sm|md|lg"`（高さの切替）
+  - `required` + `auto-validate`（submit時に value 空でエラー付与、選択変更でクリア）
+  - `error` / `error-text`（外部からの強制エラーも可）
+  - `name`/`value`/フォーム送信（Form-Associated Custom Element）
+  - `dads-change`（必要なら `dads-input` も）発火
+  - `::part()` での外部スタイル上書きが可能な part 設計
+- `viewer.html` / `src/demos.ts`
+  - セレクトのデモ（基本・サイズ・エラー・必須バリデーション・disabled/aria-disabled・幅例）
+  - `a11y-annotate` の注釈表示（既存と同様）
+
+### その他（Docs/Marketing/Infra など）
+- `packages/utils/form-component-helpers.ts` の型を `HTMLSelectElement` 対応
+  - `updateAriaDescribedBy` / `updateValidationUI` / `showValidationError` の引数型を拡張
+
+## 受入基準
+- [ ] `dads-select` が登録され、Shadow DOM 内に `<select>` が存在する
+- [ ] DADS HTML版 `select.css` と同等の見た目（border/hover/focus/chevron/error/disabled/forced-colors）になっている
+- [ ] `size="sm|md|lg"` で高さが 40/48/56px 相当に切り替わる
+- [ ] `<dads-select>` 配下の `option/optgroup` が内部 select に反映され、選択が動作する
+- [ ] `name`/`value` がフォーム値として扱われる（変更時に internals の値が更新される）
+- [ ] `required` + `auto-validate` で submit 時に未選択ならエラー表示し、選択で解除される
+- [ ] `disabled` と `aria-disabled` が両方期待通りに動作する（見た目＋操作性）
+- [ ] `viewer.html` のセレクタから Select デモを表示できる
+- [ ] Storybook ストーリーが追加され、Vitest が通る
+
+## リスク / エッジケース
+- Light DOM の option 更新（属性/テキスト/追加削除）をどこまで追従するか：MutationObserver で追従するが、頻繁な更新時のパフォーマンスに注意
+- `aria-disabled` の厳密挙動（Tab は許可、他操作は抑止）の実装がブラウザ差分を生む可能性
+- `disabled` 時のフォーム送信仕様（送信除外）が期待と合うか：Form-Associated CE としても disabled を尊重する実装にする
+- `value` 属性が存在しない/不正な場合の初期選択（先頭 option になる）を許容する
+
+## 作業項目（Action items）
+1. 承認済みPlanを保存（完了条件: `.codex/plans/2026-01-17--feature-select.md` を作成し内容がこのPlanと一致）
+2. `packages/components/select/` 追加（完了条件: `select.ts / select-styles.ts / select-tokens.ts / select-define.ts / index.ts` が揃う）
+3. options複製・属性同期・イベント/フォーム値更新を実装（完了条件: demo/テストで option/値が同期する）
+4. required/auto-validate と error UI を実装（完了条件: submitでエラー→選択で解除が動作）
+5. `disabled`/`aria-disabled` の挙動とスタイルを実装（完了条件: viewerデモで差分が確認できる）
+6. `packages/utils/form-component-helpers.ts` の型拡張（完了条件: select 実装が共通ヘルパーを利用できる）
+7. `packages/autoload/dads/select.ts` と `packages/components/index.ts` を更新（完了条件: importmap 経由で `import('dads-select')` が成功）
+8. `viewer.html` と `src/demos.ts` を更新（完了条件: ViewerでSelectデモが表示される）
+9. Storybook + Vitest を追加（完了条件: `packages/components/select/select.stories.ts` と `select.test.ts` が追加される）
+10. 最低限の検証を実行（完了条件: `npm run type-check` と `npm run test:run` が通る）
+
+## テスト計画
+- 単体: `npm run test:run`（`packages/components/select/select.test.ts` を中心に確認）
+- 型: `npm run type-check`
+- 手動: `bun server.ts` → `http://localhost:3000/?component=select` で表示・操作（required/disabled/error/size/aria-disabled）を確認
+
+## オープンクエスチョン
+- 該当なし（DADS HTML版 `select.css` と既存フォーム系コンポーネントの作法に合わせて実装方針を固定）
+

--- a/packages/autoload/dads/select.ts
+++ b/packages/autoload/dads/select.ts
@@ -1,0 +1,10 @@
+/**
+ * wc-autoloader アダプター: dads-select
+ * このファイルがインポートされるとコンポーネントが自動登録される
+ */
+import { DadsSelect, defineSelect } from '../../components/select/index.js';
+
+defineSelect();
+
+export default DadsSelect;
+

--- a/packages/components/checkbox/checkbox-styles.ts
+++ b/packages/components/checkbox/checkbox-styles.ts
@@ -208,7 +208,7 @@ export const checkboxStyles = css`
     /* サイズに応じて動的に計算（checkbox + gap） */
     padding-inline-start: calc(var(--_checkbox-size) + var(--_gap));
     font-weight: var(--font-weight-400, 400);
-    font-size: var(--font-size-14, 0.875rem);
+    font-size: var(--font-size-16, 1rem);
     line-height: var(--line-height-150, 1.5);
     font-family: var(--font-family-sans);
     color: var(--color-semantic-error-1, #ec0000);

--- a/packages/components/fieldset/fieldset-styles.ts
+++ b/packages/components/fieldset/fieldset-styles.ts
@@ -39,7 +39,7 @@ export const fieldsetStyles = css`
   /* ========== 要否ラベル ========== */
   [part='requirement'] {
     font-weight: 400;
-    font-size: 0.875rem;
+    font-size: var(--font-size-16, 1rem);
     line-height: 1.5;
     font-family: var(--font-family-sans);
     color: var(--color-semantic-error-1, #ec0000);
@@ -52,7 +52,7 @@ export const fieldsetStyles = css`
   /* ========== Support Text ========== */
   [part='support-text'] {
     margin-bottom: var(--spacing-3, 12px);
-    font-size: 0.875rem;
+    font-size: var(--font-size-16, 1rem);
     line-height: 1.5;
     font-family: var(--font-family-sans);
     color: var(--color-neutral-solid-gray-700, #4d4d4d);

--- a/packages/components/index.ts
+++ b/packages/components/index.ts
@@ -14,6 +14,9 @@ export * from './button/index.js';
 // インプットテキスト
 export * from './input-text/index.js';
 
+// セレクトボックス
+export * from './select/index.js';
+
 // カレンダー
 export * from './calendar/index.js';
 

--- a/packages/components/input-text/input-text-styles.ts
+++ b/packages/components/input-text/input-text-styles.ts
@@ -55,7 +55,7 @@ export const inputTextStyles = css`
   /* ========== サポートテキスト ========== */
   [part="support-text"] {
     margin: 0;
-    font-size: var(--font-size-14);
+    font-size: var(--font-size-16);
     color: var(--dads-input-support-color);
     line-height: var(--line-height-150);
   }
@@ -135,7 +135,7 @@ export const inputTextStyles = css`
 
   /* ========== エラーテキスト ========== */
   [part="error-text"] {
-    font-size: var(--font-size-14);
+    font-size: var(--font-size-16);
     color: var(--dads-input-error-color);
     line-height: var(--line-height-150);
   }

--- a/packages/components/input-text/input-text-tokens.ts
+++ b/packages/components/input-text/input-text-tokens.ts
@@ -20,9 +20,9 @@ const inputTextSemanticTokensText = `
     --input-label-size-lg: var(--font-size-18, 1.125rem);
 
     /* テキストサイズ */
-    --input-font-size-sm: var(--font-size-14, 0.875rem);
+    --input-font-size-sm: var(--font-size-16, 1rem);
     --input-font-size-md: var(--font-size-16, 1rem);
-    --input-font-size-lg: var(--font-size-18, 1.125rem);
+    --input-font-size-lg: var(--font-size-16, 1rem);
 
     /* 背景色 */
     --input-bg: var(--color-neutral-white, #ffffff);
@@ -134,13 +134,11 @@ const inputTextLocalTokensText = `
   /* サイズバリアント */
   :host([size="sm"]) {
     --dads-input-label-size: var(--input-label-size-sm);
-    --dads-input-font-size: var(--input-font-size-sm);
     --dads-input-height: var(--input-height-sm);
   }
 
   :host([size="lg"]) {
     --dads-input-label-size: var(--input-label-size-lg);
-    --dads-input-font-size: var(--input-font-size-lg);
     --dads-input-height: var(--input-height-lg);
   }
 

--- a/packages/components/radio/radio-tokens.ts
+++ b/packages/components/radio/radio-tokens.ts
@@ -74,7 +74,7 @@ const radioSemanticTokensText = `
     --radio-font-family: var(--font-family-sans);
     --radio-font-weight: var(--font-weight-400);
     --radio-label-line-height: var(--line-height-130);
-    --radio-error-text-font-size: var(--font-size-14);
+    --radio-error-text-font-size: var(--font-size-16);
     --radio-error-text-line-height: var(--line-height-150);
 
     /* フォーカス（DADS準拠: 黄色リング + 黒アウトライン） */

--- a/packages/components/select/index.ts
+++ b/packages/components/select/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Select Component
+ * デジタル庁デザインシステム セレクトボックスコンポーネント
+ *
+ * @module select
+ */
+export * from './select.js';
+export { defineSelect, autoDefineSelect } from './select-define.js';
+

--- a/packages/components/select/select-define.ts
+++ b/packages/components/select/select-define.ts
@@ -1,0 +1,25 @@
+/**
+ * Selectコンポーネント登録
+ */
+import { DadsSelect } from './select.js';
+
+let defined = false;
+
+/**
+ * DadsSelectコンポーネントをカスタム要素として登録する
+ */
+export function defineSelect(): void {
+  if (defined) return;
+  DadsSelect.define();
+  defined = true;
+}
+
+/**
+ * 環境がカスタム要素をサポートしている場合に自動登録する
+ */
+export function autoDefineSelect(): void {
+  if (typeof customElements !== 'undefined') {
+    defineSelect();
+  }
+}
+

--- a/packages/components/select/select-styles.ts
+++ b/packages/components/select/select-styles.ts
@@ -1,0 +1,184 @@
+/**
+ * セレクトボックスコンポーネント用スタイル定義
+ * デジタル庁デザインシステムに準拠
+ */
+import { css } from '../../core/web-components.js';
+
+export const selectStyles = css`
+  /* ========== ホストレベル共通設定 ========== */
+  :host {
+    display: block;
+    font-family: var(--font-family-sans);
+  }
+
+  /* ========== ラッパー ========== */
+  [part="wrapper"] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--select-gap);
+  }
+
+  /* ========== ラベル ========== */
+  [part="label"] {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 0;
+    font-size: var(--dads-select-label-size);
+    font-weight: var(--dads-select-label-weight);
+    color: var(--dads-select-label-color);
+    line-height: var(--line-height-150);
+  }
+
+  [part="label-text"] {
+    display: contents;
+  }
+
+  /* ========== 要否ラベル ========== */
+  [part="requirement"] {
+    margin-left: var(--select-requirement-margin);
+    font-weight: var(--font-weight-400);
+    font-size: var(--font-size-16);
+    color: var(--dads-select-requirement-color);
+  }
+
+  /* ========== サポートテキスト ========== */
+  [part="support-text"] {
+    margin: 0;
+    font-size: var(--font-size-16);
+    color: var(--dads-select-support-color);
+    line-height: var(--line-height-150);
+  }
+
+  /* ========== Selectラッパー ========== */
+  [part="select-wrapper"] {
+    position: relative;
+    width: var(--dads-select-width);
+    max-width: 100%;
+  }
+
+  /* ========== Select本体（DADS select.css相当） ========== */
+  [part="select"] {
+    vertical-align: middle;
+    box-sizing: border-box;
+    width: 100%;
+    height: var(--dads-select-height);
+
+    /* プロパティと変数のマッピング（一度だけ定義） */
+    background-color: var(--dads-select-background);
+    color: var(--dads-select-color);
+    border: var(--dads-select-border-width) solid var(--dads-select-border-color);
+    border-radius: var(--dads-select-border-radius);
+    padding: var(--dads-select-padding-y) var(--dads-select-padding-right) var(--dads-select-padding-y)
+      var(--dads-select-padding-left);
+
+    font-family: var(--font-family-sans);
+    font-size: var(--dads-select-font-size);
+    letter-spacing: var(--dads-select-letter-spacing);
+    line-height: 1;
+
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+  }
+
+  /* ホバー状態 */
+  @media (hover: hover) {
+    [part="select"]:not(:disabled):not([aria-disabled="true"]):hover {
+      --dads-select-border-color: var(--select-border-hover);
+    }
+  }
+
+  /* フォーカス状態（DADS公式準拠） */
+  [part="select"]:focus {
+    outline: none;
+  }
+
+  [part="select"]:focus-visible {
+    outline: var(--dads-focus-outline-width) solid var(--dads-focus-outline-color);
+    outline-offset: var(--dads-focus-outline-offset);
+    box-shadow: 0 0 0 var(--dads-focus-ring-width) var(--dads-focus-ring-color);
+  }
+
+  /* エラー状態（ホストのerror属性に同期） */
+  :host([error]) [part="select"] {
+    --dads-select-border-color: var(--select-border-error);
+  }
+
+  @media (hover: hover) {
+    :host([error]) [part="select"]:not(:disabled):not([aria-disabled="true"]):hover {
+      --dads-select-border-color: var(--select-border-error-hover);
+    }
+  }
+
+  /* disabled/aria-disabled 状態 */
+  [part="select"]:is(:disabled, [aria-disabled="true"]),
+  [part="select"]:is(:disabled, [aria-disabled="true"]):hover {
+    --dads-select-background: var(--select-bg-disabled);
+    --dads-select-border-color: var(--select-border-disabled);
+    --dads-select-color: var(--select-text-disabled);
+    cursor: not-allowed;
+  }
+
+  /* aria-disabled は「readonly相当」: Tab移動は可能だが、ポインタ操作は抑止 */
+  [part="select"][aria-disabled="true"] {
+    pointer-events: none;
+  }
+
+  /* ========== Chevron ========== */
+  [part="select-chevron"] {
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    right: var(--spacing-4);
+    bottom: 0;
+    margin-top: auto;
+    margin-bottom: auto;
+    width: var(--spacing-4);
+    height: var(--spacing-4);
+    color: var(--dads-select-chevron-color);
+  }
+
+  [part="select"]:is(:disabled, [aria-disabled="true"]) + [part="select-chevron"] {
+    --dads-select-chevron-color: var(--select-text-disabled);
+  }
+
+  /* ========== エラーテキスト ========== */
+  [part="error-text"] {
+    font-size: var(--font-size-16);
+    color: var(--dads-select-error-color);
+    line-height: var(--line-height-150);
+  }
+
+  /* ========== 強制カラーモード対応 ========== */
+  @media (forced-colors: active) {
+    [part="select"] {
+      color: ButtonText;
+      border-color: ButtonText;
+    }
+
+    [part="select"][aria-disabled="true"],
+    [part="select"][aria-disabled="true"]:hover,
+    [part="select"]:disabled,
+    [part="select"]:disabled:hover {
+      border-color: GrayText;
+      color: GrayText;
+    }
+
+    [part="select-chevron"] {
+      color: ButtonText;
+    }
+
+    [part="select"]:is(:disabled, [aria-disabled="true"]) + [part="select-chevron"] {
+      color: GrayText;
+    }
+  }
+
+  /* ========== 印刷対応 ========== */
+  @media print {
+    [part="select"] {
+      background-color: transparent;
+      border: 1px solid black;
+    }
+  }
+`;

--- a/packages/components/select/select-tokens.ts
+++ b/packages/components/select/select-tokens.ts
@@ -1,0 +1,142 @@
+/**
+ * セレクトボックスコンポーネント用デザイントークン
+ * デジタル庁デザインシステム準拠
+ *
+ * セマンティックトークンとローカルコンポーネントトークンの2層構造
+ */
+import { css } from '../../core/web-components.js';
+
+/**
+ * セレクトボックスセマンティックトークン
+ */
+const selectSemanticTokensText = `
+  :host {
+    /* ========== セマンティックトークン（意味的な値） ========== */
+
+    /* ラベルサイズ（DADS準拠: sm/md/lg） */
+    --select-label-size-sm: var(--font-size-16, 1rem);
+    --select-label-size-md: var(--font-size-17, 1.0625rem);
+    --select-label-size-lg: var(--font-size-18, 1.125rem);
+
+    /* ラベル */
+    --select-label-color: var(--color-neutral-solid-gray-800, #333333);
+    --select-label-weight: var(--font-weight-700, 700);
+
+    /* 要否ラベル */
+    --select-requirement-color: var(--color-semantic-error-1, #ec0000);
+
+    /* サポートテキスト */
+    --select-support-color: var(--color-neutral-solid-gray-600, #666666);
+
+    /* エラーテキスト */
+    --select-error-text-color: var(--color-semantic-error-1, #ec0000);
+
+    /* 背景色 */
+    --select-bg: var(--color-neutral-white, #ffffff);
+    --select-bg-disabled: var(--color-neutral-solid-gray-50, #f2f2f2);
+
+    /* ボーダー色 */
+    --select-border: var(--color-neutral-solid-gray-600, #666666);
+    --select-border-hover: var(--color-neutral-black, #000000);
+    --select-border-error: var(--color-semantic-error-1, #ec0000);
+    --select-border-error-hover: var(--color-primitive-red-1000, #a90000);
+    --select-border-disabled: var(--color-neutral-solid-gray-300, #b3b3b3);
+
+    /* テキスト色 */
+    --select-text: var(--color-neutral-solid-gray-800, #333333);
+    --select-text-disabled: var(--color-neutral-solid-gray-420, #949494);
+
+    /* タイポグラフィ */
+    --select-font-size: var(--font-size-16, 1rem);
+    --select-letter-spacing: 0.02em;
+
+    /* レイアウト */
+    --select-border-width: 1px;
+    --select-border-radius: var(--border-radius-8, 0.5rem);
+    --select-padding-y: calc(11 / 16 * 1rem);
+    --select-padding-left: var(--spacing-4, 1rem);
+    --select-padding-right: var(--spacing-10, 2.5rem);
+
+    /* 高さ */
+    --select-height-sm: 40px;
+    --select-height-md: 48px;
+    --select-height-lg: 56px;
+
+    /* 間隔 */
+    --select-gap: var(--spacing-2, 0.5rem);
+    --select-requirement-margin: var(--spacing-1, 0.25rem);
+
+    /* 幅（デフォルト: コンテナにフィット） */
+    --select-width: 100%;
+  }
+`;
+
+/**
+ * セレクトボックスローカルコンポーネントトークン（API）
+ */
+const selectLocalTokensText = `
+  :host {
+    /* ========== ローカルコンポーネントトークン（カスタマイズ用） ========== */
+
+    /* Select */
+    --dads-select-background: var(--select-bg);
+    --dads-select-border-color: var(--select-border);
+    --dads-select-border-width: var(--select-border-width);
+    --dads-select-border-radius: var(--select-border-radius);
+    --dads-select-color: var(--select-text);
+    --dads-select-font-size: var(--select-font-size);
+    --dads-select-letter-spacing: var(--select-letter-spacing);
+    --dads-select-padding-y: var(--select-padding-y);
+    --dads-select-padding-left: var(--select-padding-left);
+    --dads-select-padding-right: var(--select-padding-right);
+    --dads-select-height: var(--select-height-md);
+    --dads-select-width: var(--select-width);
+
+    /* Chevron */
+    --dads-select-chevron-color: currentColor;
+
+    /* Label */
+    --dads-select-label-size: var(--select-label-size-md);
+    --dads-select-label-color: var(--select-label-color);
+    --dads-select-label-weight: var(--select-label-weight);
+
+    /* Requirement */
+    --dads-select-requirement-color: var(--select-requirement-color);
+
+    /* Support text */
+    --dads-select-support-color: var(--select-support-color);
+
+    /* Error */
+    --dads-select-error-color: var(--select-error-text-color);
+  }
+
+  /* サイズバリアント */
+  :host([size~="sm"]) {
+    --dads-select-label-size: var(--select-label-size-sm);
+    --dads-select-height: var(--select-height-sm);
+  }
+
+  :host([size~="lg"]) {
+    --dads-select-label-size: var(--select-label-size-lg);
+    --dads-select-height: var(--select-height-lg);
+  }
+
+  /* エラー状態（ボーダー色） */
+  :host([error]) {
+    --dads-select-border-color: var(--select-border-error);
+  }
+`;
+
+/**
+ * 個別エクスポート（後方互換性のため）
+ */
+export const selectSemanticTokens = css`${selectSemanticTokensText}`;
+export const selectLocalTokens = css`${selectLocalTokensText}`;
+
+/**
+ * 統合トークン（セマンティック + ローカル）
+ */
+export const selectTokens = css`
+  ${selectSemanticTokensText}
+  ${selectLocalTokensText}
+`;

--- a/packages/components/select/select.stories.ts
+++ b/packages/components/select/select.stories.ts
@@ -1,0 +1,207 @@
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { defineSelect } from './select-define';
+
+// コンポーネントを登録
+defineSelect();
+
+type SelectArgs = {
+  label?: string;
+  supportText?: string;
+  required?: boolean;
+  error?: boolean;
+  errorText?: string;
+  disabled?: boolean;
+  ariaDisabled?: boolean;
+  name?: string;
+  size?: 'sm' | 'md' | 'lg';
+  width?: string;
+  value?: string;
+};
+
+const meta: Meta<SelectArgs> = {
+  title: 'Components/DADS Select',
+  tags: ['autodocs'],
+  render: (args) => {
+    const select = document.createElement('dads-select');
+
+    if (args.label) select.setAttribute('label', args.label);
+    if (args.supportText) select.setAttribute('support-text', args.supportText);
+    if (args.required) select.setAttribute('required', '');
+    if (args.error) select.setAttribute('error', '');
+    if (args.errorText) select.setAttribute('error-text', args.errorText);
+    if (args.disabled) select.setAttribute('disabled', '');
+    if (args.ariaDisabled) select.setAttribute('aria-disabled', 'true');
+    if (args.name) select.setAttribute('name', args.name);
+    if (args.size || args.width) {
+      const sizeTokens = [args.size, args.width].filter(Boolean).join(' ');
+      select.setAttribute('size', sizeTokens);
+    }
+    if (args.value) select.setAttribute('value', args.value);
+
+    select.innerHTML = `
+      <option value="">選択してください</option>
+      <option value="1">選択肢1</option>
+      <option value="2">選択肢2</option>
+      <option value="3">選択肢3</option>
+    `;
+
+    return select;
+  },
+  argTypes: {
+    label: {
+      control: 'text',
+      description: 'ラベルテキスト',
+    },
+    supportText: {
+      control: 'text',
+      description: 'サポートテキスト（ヒント）',
+    },
+    required: {
+      control: 'boolean',
+      description: '必須項目',
+      table: { defaultValue: { summary: false } },
+    },
+    error: {
+      control: 'boolean',
+      description: 'エラー状態',
+      table: { defaultValue: { summary: false } },
+    },
+    errorText: {
+      control: 'text',
+      description: 'エラーメッセージ',
+    },
+    disabled: {
+      control: 'boolean',
+      description: '無効状態（disabled）',
+      table: { defaultValue: { summary: false } },
+    },
+    ariaDisabled: {
+      control: 'boolean',
+      description: '無効相当（aria-disabled）',
+      table: { defaultValue: { summary: false } },
+    },
+    name: {
+      control: 'text',
+      description: 'フォーム名',
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['sm', 'md', 'lg'],
+      description: 'サイズ（sm / md / lg）',
+      table: { defaultValue: { summary: 'md' } },
+    },
+    width: {
+      control: 'text',
+      description: '幅指定（size属性に追加トークンとして指定: 例 "256", "256px", "20ch", "full", "fit-content"）',
+    },
+    value: {
+      control: 'text',
+      description: '初期値',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: `
+# デジタル庁デザインシステム Select（セレクトボックス）コンポーネント
+
+デジタル庁デザインシステム準拠のセレクトボックス（単一選択）コンポーネントです。
+
+## 特徴
+- ラベル・サポートテキスト・要否表示（※必須）
+- エラー状態とエラーメッセージ表示
+- サイズバリエーション（sm / md / lg）
+- size属性で幅指定（例: size="md 256" / size="md full" / size="md fit-content"）
+- disabled と aria-disabled（readonly相当）をサポート
+- Shadow DOM + ::part() によるカスタマイズ
+- Form Associated Custom Elementとしてフォームに参加
+
+## 使用方法
+
+\`\`\`html
+<dads-select label="都道府県" support-text="選択してください" required>
+  <option value="">選択してください</option>
+  <option value="tokyo">東京都</option>
+  <option value="kanagawa">神奈川県</option>
+</dads-select>
+
+<!-- 幅指定（数値のみは px 扱い） -->
+<dads-select label="都道府県" size="md 256">
+  <option value="">選択してください</option>
+  <option value="tokyo">東京都</option>
+</dads-select>
+\`\`\`
+
+## スロット
+
+| スロット名 | 説明 |
+|-----------|------|
+| label | ラベルテキスト |
+| support-text | サポートテキスト |
+| error-text | エラーメッセージ |
+| required-error | 必須バリデーション用カスタムエラーメッセージ |
+| (default) | option / optgroup（内部selectへ複製） |
+
+## CSSパーツ
+
+| パーツ名 | 説明 |
+|---------|------|
+| wrapper | 全体を囲むコンテナ |
+| label | ラベル要素 |
+| label-text | ラベルテキストラッパー |
+| requirement | 要否ラベル（※必須） |
+| support-text | サポートテキストコンテナ |
+| select-wrapper | selectを囲むコンテナ |
+| select | ネイティブselect要素 |
+| select-chevron | セレクトの矢印アイコン |
+| error-text | エラーメッセージコンテナ |
+        `,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<SelectArgs>;
+
+export const Default: Story = {
+  args: {
+    label: '都道府県',
+    supportText: 'お住まいの都道府県を選択してください',
+    size: 'md',
+  },
+};
+
+export const Required: Story = {
+  name: '必須項目',
+  args: {
+    ...Default.args,
+    required: true,
+  },
+};
+
+export const Errored: Story = {
+  name: 'エラー状態',
+  args: {
+    ...Default.args,
+    error: true,
+    errorText: '選択してください',
+  },
+};
+
+export const Disabled: Story = {
+  name: 'Disabled',
+  args: {
+    ...Default.args,
+    disabled: true,
+  },
+};
+
+export const AriaDisabled: Story = {
+  name: 'Aria Disabled',
+  args: {
+    ...Default.args,
+    ariaDisabled: true,
+    value: '2',
+  },
+};

--- a/packages/components/select/select.test.ts
+++ b/packages/components/select/select.test.ts
@@ -1,0 +1,301 @@
+/**
+ * DadsSelectコンポーネント テスト
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { waitFor } from '@testing-library/dom';
+import {
+  createTestElement,
+  cleanupTestElement,
+  getShadowContent,
+  renderWebComponent,
+  waitForCustomElement,
+} from '../../../tests/setup';
+
+const basicOptions = `
+  <option value="">選択してください</option>
+  <option value="1">選択肢1</option>
+  <option value="2">選択肢2</option>
+`;
+
+async function defineSelectForTest(): Promise<void> {
+  const { defineSelect } = await import('./select-define');
+  defineSelect();
+}
+
+// ========== Phase 1: 基本レンダリング ==========
+describe('DadsSelect - 基本レンダリング', () => {
+  let element: HTMLElement;
+
+  afterEach(() => {
+    if (element) cleanupTestElement(element);
+  });
+
+  it('コンポーネントが存在する', async () => {
+    await defineSelectForTest();
+
+    element = createTestElement('dads-select');
+    await waitForCustomElement(element);
+
+    expect(element).toBeInTheDocument();
+  });
+
+  it('Shadow DOMが作成される', async () => {
+    await defineSelectForTest();
+
+    element = createTestElement('dads-select');
+    await waitForCustomElement(element);
+
+    expect(element.shadowRoot).toBeTruthy();
+  });
+
+  it('select要素が含まれる', async () => {
+    await defineSelectForTest();
+
+    element = createTestElement('dads-select');
+    await waitForCustomElement(element);
+
+    const select = getShadowContent(element, '[part="select"]');
+    expect(select).toBeInTheDocument();
+    expect(select?.tagName.toLowerCase()).toBe('select');
+  });
+});
+
+// ========== Phase 2: option同期 ==========
+describe('DadsSelect - option同期', () => {
+  let element: HTMLElement;
+
+  afterEach(() => {
+    if (element) cleanupTestElement(element);
+  });
+
+  it('Light DOMのoptionが内部selectに複製される', async () => {
+    await defineSelectForTest();
+
+    element = renderWebComponent(`
+      <dads-select>
+        ${basicOptions}
+      </dads-select>
+    `);
+    await waitForCustomElement(element);
+
+    const select = getShadowContent(element, '[part="select"]') as HTMLSelectElement;
+    expect(select.options.length).toBe(3);
+    expect(select.options[1].textContent).toBe('選択肢1');
+    expect(select.options[2].value).toBe('2');
+  });
+
+  it('value属性で初期選択が反映される', async () => {
+    await defineSelectForTest();
+
+    element = renderWebComponent(`
+      <dads-select value="2">
+        ${basicOptions}
+      </dads-select>
+    `);
+    await waitForCustomElement(element);
+
+    const select = getShadowContent(element, '[part="select"]') as HTMLSelectElement;
+    expect(select.value).toBe('2');
+  });
+
+  it('selected属性が初期選択として機能する（value属性未指定）', async () => {
+    await defineSelectForTest();
+
+    element = renderWebComponent(`
+      <dads-select>
+        <option value="1">選択肢1</option>
+        <option value="2" selected>選択肢2</option>
+        <option value="3">選択肢3</option>
+      </dads-select>
+    `);
+    await waitForCustomElement(element);
+
+    const select = getShadowContent(element, '[part="select"]') as HTMLSelectElement;
+    expect(select.value).toBe('2');
+  });
+});
+
+// ========== Phase 3: 属性反映 ==========
+describe('DadsSelect - 属性反映', () => {
+  let element: HTMLElement;
+
+  afterEach(() => {
+    if (element) cleanupTestElement(element);
+  });
+
+  it('label属性がフォールバックとして機能する', async () => {
+    await defineSelectForTest();
+
+    element = createTestElement('dads-select');
+    element.setAttribute('label', 'テストラベル');
+    await waitForCustomElement(element);
+
+    const labelText = getShadowContent(element, '[part="label-text"]');
+    expect(labelText?.textContent).toContain('テストラベル');
+  });
+
+  it('required属性で「※必須」ラベルが表示される', async () => {
+    await defineSelectForTest();
+
+    element = createTestElement('dads-select');
+    element.setAttribute('required', '');
+    await waitForCustomElement(element);
+
+    const requirement = getShadowContent(element, '[part="requirement"]');
+    expect(requirement?.textContent).toBe('※必須');
+  });
+
+  it('デフォルトでsize="md"が適用される', async () => {
+    await defineSelectForTest();
+
+    element = createTestElement('dads-select');
+    await waitForCustomElement(element);
+
+    expect(element.getAttribute('size')).toBe('md');
+  });
+
+  it('size属性で幅トークンを指定できる（例: size="sm 256"）', async () => {
+    await defineSelectForTest();
+
+    element = renderWebComponent(`
+      <dads-select size="sm 256">
+        <option value="">選択してください</option>
+        <option value="1">選択肢1</option>
+      </dads-select>
+    `);
+    await waitForCustomElement(element);
+
+    expect(element.style.getPropertyValue('--dads-select-width')).toBe('256px');
+
+    const select = getShadowContent(element, '[part="select"]') as HTMLSelectElement;
+    expect(select.getAttribute('data-size')).toBe('sm');
+  });
+
+  it('aria-disabled属性で内部selectにaria-disabled="true"が反映される', async () => {
+    await defineSelectForTest();
+
+    element = createTestElement('dads-select');
+    element.setAttribute('aria-disabled', '');
+    await waitForCustomElement(element);
+
+    const select = getShadowContent(element, '[part="select"]') as HTMLSelectElement;
+    expect(select.getAttribute('aria-disabled')).toBe('true');
+  });
+});
+
+// ========== Phase 4: 必須バリデーション ==========
+describe('DadsSelect - 必須バリデーション', () => {
+  let element: HTMLElement;
+  let form: HTMLFormElement;
+
+  afterEach(() => {
+    if (element) cleanupTestElement(element);
+    if (form) form.remove();
+  });
+
+  it('auto-validate + requiredなしで送信時にエラー表示されない', async () => {
+    await defineSelectForTest();
+
+    form = document.createElement('form');
+    element = document.createElement('dads-select');
+    element.setAttribute('auto-validate', '');
+    element.innerHTML = `
+      <option value="">選択してください</option>
+      <option value="1">選択肢1</option>
+    `;
+    form.appendChild(element);
+    document.body.appendChild(form);
+    await waitForCustomElement(element);
+
+    const submitEvent = new Event('submit', { cancelable: true });
+    form.dispatchEvent(submitEvent);
+
+    await waitFor(() => {
+      expect(element.hasAttribute('error')).toBe(false);
+    });
+  });
+
+  it('auto-validate + required時、未選択で送信するとエラー表示', async () => {
+    await defineSelectForTest();
+
+    form = document.createElement('form');
+    element = document.createElement('dads-select');
+    element.setAttribute('auto-validate', '');
+    element.setAttribute('required', '');
+    element.innerHTML = `
+      <option value="">選択してください</option>
+      <option value="1">選択肢1</option>
+    `;
+    form.appendChild(element);
+    document.body.appendChild(form);
+    await waitForCustomElement(element);
+
+    const submitEvent = new Event('submit', { cancelable: true });
+    form.dispatchEvent(submitEvent);
+
+    await waitFor(() => {
+      expect(element.hasAttribute('error')).toBe(true);
+    });
+  });
+
+  it('required-errorスロットでカスタムメッセージ使用', async () => {
+    await defineSelectForTest();
+
+    form = document.createElement('form');
+    element = document.createElement('dads-select');
+    element.setAttribute('auto-validate', '');
+    element.setAttribute('required', '');
+    element.innerHTML = `
+      <option value="">選択してください</option>
+      <option value="1">選択肢1</option>
+    `;
+    const customMessage = document.createElement('span');
+    customMessage.slot = 'required-error';
+    customMessage.textContent = '選択してください（カスタム）';
+    element.appendChild(customMessage);
+    form.appendChild(element);
+    document.body.appendChild(form);
+    await waitForCustomElement(element);
+
+    const submitEvent = new Event('submit', { cancelable: true });
+    form.dispatchEvent(submitEvent);
+
+    await waitFor(() => {
+      expect(element.getAttribute('error-text')).toBe('選択してください（カスタム）');
+    });
+  });
+
+  it('選択後はエラーがクリアされる（auto-validate）', async () => {
+    await defineSelectForTest();
+
+    form = document.createElement('form');
+    element = document.createElement('dads-select');
+    element.setAttribute('auto-validate', '');
+    element.setAttribute('required', '');
+    element.innerHTML = `
+      <option value="">選択してください</option>
+      <option value="1">選択肢1</option>
+    `;
+    form.appendChild(element);
+    document.body.appendChild(form);
+    await waitForCustomElement(element);
+
+    // 1) submitでエラー
+    const submitEvent = new Event('submit', { cancelable: true });
+    form.dispatchEvent(submitEvent);
+
+    await waitFor(() => {
+      expect(element.hasAttribute('error')).toBe(true);
+    });
+
+    // 2) 選択してinputイベントでクリア
+    const select = getShadowContent(element, '[part="select"]') as HTMLSelectElement;
+    select.value = '1';
+    select.dispatchEvent(new Event('input', { bubbles: true }));
+
+    await waitFor(() => {
+      expect(element.hasAttribute('error')).toBe(false);
+    });
+  });
+});

--- a/packages/components/select/select.ts
+++ b/packages/components/select/select.ts
@@ -1,0 +1,724 @@
+/**
+ * @module select
+ * デジタル庁デザインシステム Selectコンポーネント
+ * @version 1.0.0
+ */
+
+import { html, BooleanAttr, PropertyAttr } from '../../core/web-components.js';
+import { TypographyFormComponent } from '../../core/typography/typography-web-component.js';
+import { applyDADSTokens } from '../../styles/design-tokens/index.js';
+import { applySpacingTokens } from '../../styles/spacing-tokens.js';
+import { selectTokens } from './select-tokens.js';
+import { selectStyles } from './select-styles.js';
+import { withReset } from '../../styles/reset-css.js';
+import { applyDADSFocusStyles } from '../../styles/mixins/focus-styles-official.js';
+import { applyStandardFormElementBehavior } from '../../utils/behaviors.js';
+import { VALIDATION_RULES, getValidationMessage } from '../../utils/validation.js';
+import {
+  setDefaultAttributes,
+  setupFormValidation,
+  updateLabelFallback,
+  updateSupportFallback,
+  updateErrorFallback,
+  updateRequirement,
+  updateValidationUI,
+  showValidationError,
+  clearValidationError,
+  updateAriaDescribedBy,
+  setupSlotChangeListeners,
+  type FormValidationSetup,
+} from '../../utils/form-component-helpers.js';
+import type { A11yAnnotations } from '../../utils/a11y-annotations.js';
+
+/**
+ * Selectコンポーネント
+ *
+ * @customElement dads-select
+ * @tagname dads-select
+ *
+ * @slot label - ラベルテキスト
+ * @slot support-text - サポートテキスト（ヒント）
+ * @slot error-text - エラーメッセージ
+ * @slot required-error - 必須バリデーションのカスタムエラーメッセージ
+ * @slot - option / optgroup（Light DOMに配置、内部selectへ複製）
+ *
+ * @csspart wrapper - 全体を囲むコンテナ
+ * @csspart label - ラベル要素
+ * @csspart label-text - ラベルテキストラッパー
+ * @csspart requirement - 要否ラベル（※必須）
+ * @csspart support-text - サポートテキストコンテナ
+ * @csspart select-wrapper - selectを囲むコンテナ
+ * @csspart select - ネイティブselect要素
+ * @csspart select-chevron - セレクトの矢印アイコン
+ * @csspart error-text - エラーメッセージコンテナ
+ *
+ * @attr {string} label - ラベルテキスト（スロット未使用時のフォールバック）
+ * @attr {string} support-text - サポートテキスト（スロット未使用時のフォールバック）
+ * @attr {boolean} required - 必須項目
+ * @attr {boolean} error - エラー状態
+ * @attr {string} error-text - エラーメッセージ（スロット未使用時のフォールバック）
+ * @attr {boolean} disabled - 無効状態（ネイティブdisabled）
+ * @attr {string} aria-disabled - 無効相当（Tab移動は許容、操作は抑止）
+ * @attr {string} name - フォーム名
+ * @attr {string} size - サイズ（sm | md | lg）+ 幅指定（例: "md 256", "sm 20ch", "lg full", "md fit-content"）
+ * @attr {boolean} auto-validate - 自動バリデーションを有効化
+ * @attr {string} value - 初期値
+ *
+ * @fires dads-input - 入力時に発火
+ * @fires dads-change - 値変更確定時に発火
+ */
+export class DadsSelect extends TypographyFormComponent {
+  static readonly formAssociated = true;
+
+  // Private fields
+  #select: HTMLSelectElement | null = null;
+  #labelSlot: HTMLSlotElement | null = null;
+  #supportSlot: HTMLSlotElement | null = null;
+  #errorSlot: HTMLSlotElement | null = null;
+
+  // UI要素参照
+  #labelFallback: HTMLElement | null = null;
+  #supportText: HTMLElement | null = null;
+  #supportFallback: HTMLElement | null = null;
+  #errorText: HTMLElement | null = null;
+  #errorFallback: HTMLElement | null = null;
+  #requirement: HTMLElement | null = null;
+
+  // バリデーション状態
+  #validationErrorType: 'required' | null = null;
+
+  // フォームバリデーションセットアップ
+  #formValidation: FormValidationSetup | null = null;
+
+  // フォーム由来のdisabled状態（fieldset disabled等）
+  #formDisabled = false;
+
+  // Light DOM option監視
+  #optionsObserver: MutationObserver | null = null;
+
+  static definition = {
+    name: 'dads-select',
+    template: html`
+      <div part="wrapper" id="wrapper">
+        <label part="label" id="label" for="select">
+          <span part="label-text" id="label-text">
+            <slot name="label" id="label-slot"></slot>
+            <span id="label-fallback"></span>
+          </span>
+          <span part="requirement" id="requirement"></span>
+        </label>
+
+        <div part="support-text" id="support-text">
+          <slot name="support-text" id="support-slot"></slot>
+          <span id="support-fallback"></span>
+        </div>
+
+        <div part="select-wrapper" id="select-wrapper">
+          <select part="select" id="select"></select>
+          <svg part="select-chevron" width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 17L3 8L4 7L12 15L20 7L21 8L12 17Z" fill="currentcolor" />
+          </svg>
+        </div>
+
+        <div part="error-text" id="error-text">
+          <slot name="error-text" id="error-slot"></slot>
+          <span id="error-fallback"></span>
+        </div>
+
+        <!-- バリデーション用カスタムエラーメッセージスロット（非表示） -->
+        <slot name="required-error" id="required-error-slot" hidden></slot>
+      </div>
+    `,
+    styles: withReset(
+      [applyDADSTokens(), applySpacingTokens(), selectTokens, selectStyles, applyDADSFocusStyles()],
+      'minimal'
+    ),
+    attributes: [
+      PropertyAttr('label'),
+      PropertyAttr('support-text'),
+      BooleanAttr('required'),
+      BooleanAttr('error'),
+      PropertyAttr('error-text'),
+      BooleanAttr('disabled'),
+      // aria-disabled は文字列属性（"true"/"false" だけでなく空文字も許容）
+      { attribute: 'aria-disabled' },
+      PropertyAttr('name'),
+      PropertyAttr('size'),
+      BooleanAttr('auto-validate'),
+      // value は observedAttributes に含めるが、PropertyAttr は使わない（カスタム getter/setter）
+      { attribute: 'value' },
+    ],
+  };
+
+  static readonly a11yAnnotations: A11yAnnotations = {
+    version: 1,
+    summary: 'セレクトボックスコンポーネント仕様（アクセシビリティ注釈）',
+    categories: {
+      semantics: [
+        'ネイティブの <select> 要素を使用し、単一選択のセマンティクスを提供します。',
+        '<label> 要素でラベルとselectを関連付けます。',
+        'Form-Associated Custom Elementとしてネイティブフォームに参加します。',
+      ],
+      keyboard: [
+        'Tabでフォーカス可能です。',
+        '標準のセレクトボックスのキーボード操作が利用できます（aria-disabled時はTab以外抑止）。',
+      ],
+      zoom: [
+        'サイズバリエーション: sm / md / lg。',
+        'size属性の追加トークンで幅指定が可能（例: size="md 256", size="md full", size="md fit-content"）。',
+        'テキストは相対単位で定義され、拡大時も操作可能です。',
+      ],
+      states: [
+        'required属性で「※必須」ラベル表示、aria-required="true"設定。',
+        'disabled属性で無効状態（ネイティブdisabled）。',
+        'aria-disabled属性で無効相当状態（Tab移動は許容、操作は抑止）。',
+        'error属性でエラー状態（aria-invalid="true"、赤枠表示）。',
+      ],
+      labels: [
+        'label属性またはスロットでラベルを提供します。',
+        'support-text属性またはスロットで補足説明を提供、aria-describedbyで関連付け。',
+        'error-text属性またはスロットでエラーメッセージを提供、aria-describedbyで関連付け。',
+      ],
+      motion: [
+        'アニメーションは使用しません。',
+      ],
+    },
+    callouts: [
+      {
+        id: 'label',
+        title: 'ラベル要素',
+        label: '<label>',
+        description: 'ネイティブのlabel要素でselectと関連付けます。クリックでフォーカス移動。',
+        category: 'semantics',
+        placement: 'top-left',
+        target: { scope: 'shadow', selector: '[part="label"]' },
+      },
+      {
+        id: 'requirement',
+        title: '要否ラベル',
+        label: '※必須',
+        description: 'required属性に応じて表示されるラベルです。',
+        category: 'labels',
+        placement: 'top-right',
+        target: { scope: 'shadow', selector: '[part="requirement"]' },
+      },
+      {
+        id: 'support-text',
+        title: 'サポートテキスト',
+        label: 'support-text',
+        description: '入力のヒントや補足説明を提供します。aria-describedbyで関連付け。',
+        category: 'labels',
+        placement: 'bottom-left',
+        target: { scope: 'shadow', selector: '[part="support-text"]' },
+      },
+      {
+        id: 'select',
+        title: 'ネイティブ選択要素',
+        label: '<select>',
+        description: '選択肢（option/optgroup）はLight DOMから複製して内部selectに設定します。',
+        category: 'keyboard',
+        placement: 'top-right',
+        target: { scope: 'shadow', selector: '[part="select"]' },
+      },
+      {
+        id: 'chevron',
+        title: 'シェブロンアイコン',
+        label: 'chevron',
+        description: '選択肢であることを示す装飾アイコンです（aria-hidden）。',
+        category: 'semantics',
+        placement: 'top-right',
+        target: { scope: 'shadow', selector: '[part="select-chevron"]' },
+      },
+      {
+        id: 'error-text',
+        title: 'エラーメッセージ',
+        label: 'error-text',
+        description: 'バリデーションエラー時に表示。aria-describedbyで関連付け（DADSガイドライン準拠）。',
+        category: 'states',
+        placement: 'bottom-right',
+        target: { scope: 'shadow', selector: '[part="error-text"]' },
+      },
+    ],
+  };
+
+  connectedCallback(): void {
+    super.connectedCallback();
+
+    // デフォルト属性の設定
+    setDefaultAttributes(this, { size: 'md' });
+
+    // 内部要素の参照を取得
+    this.#select = this.shadowRoot?.querySelector('[part="select"]') as HTMLSelectElement;
+    this.#labelSlot = this.shadowRoot?.querySelector('#label-slot') as HTMLSlotElement;
+    this.#supportSlot = this.shadowRoot?.querySelector('#support-slot') as HTMLSlotElement;
+    this.#errorSlot = this.shadowRoot?.querySelector('#error-slot') as HTMLSlotElement;
+
+    // UI要素参照取得
+    this.#labelFallback = this.shadowRoot?.querySelector('#label-fallback') as HTMLElement;
+    this.#supportText = this.shadowRoot?.querySelector('#support-text') as HTMLElement;
+    this.#supportFallback = this.shadowRoot?.querySelector('#support-fallback') as HTMLElement;
+    this.#errorText = this.shadowRoot?.querySelector('#error-text') as HTMLElement;
+    this.#errorFallback = this.shadowRoot?.querySelector('#error-fallback') as HTMLElement;
+    this.#requirement = this.shadowRoot?.querySelector('#requirement') as HTMLElement;
+
+    // 初期化
+    this.#initSelect();
+    this.#initSlots();
+    this.#setupFormValidation();
+    this.#setupOptionsObserver();
+
+    // 属性が接続後に設定された場合のために再同期
+    queueMicrotask(() => {
+      if (!this.isConnected) return;
+      this.#syncAllState();
+    });
+  }
+
+  disconnectedCallback(): void {
+    this.#select?.removeEventListener('input', this.#handleInput);
+    this.#select?.removeEventListener('change', this.#handleChange);
+    this.#select?.removeEventListener('keydown', this.#handleAriaDisabledKeydown);
+    this.#select?.removeEventListener('mousedown', this.#handleAriaDisabledMouseDown);
+
+    this.#formValidation?.cleanup();
+    this.#formValidation = null;
+
+    this.#optionsObserver?.disconnect();
+    this.#optionsObserver = null;
+
+    super.disconnectedCallback();
+  }
+
+  #syncAllState(): void {
+    this.#syncOptions();
+    this.#syncSelectAttributes();
+    updateLabelFallback(this.#labelSlot, this.#labelFallback, this.getAttribute('label'));
+    updateSupportFallback(
+      this.#supportSlot,
+      this.#supportText,
+      this.#supportFallback,
+      this.getAttribute('support-text')
+    );
+    updateErrorFallback(
+      this.#errorSlot,
+      this.#errorText,
+      this.#errorFallback,
+      this.getAttribute('error-text'),
+      this.hasAttribute('error')
+    );
+    updateRequirement(this.#requirement, this.hasAttribute('required'), false);
+    this.#updateAriaDescribedBy();
+
+    if (this.#select) {
+      this._internals.setFormValue(this.#select.value);
+    }
+  }
+
+  #initSelect(): void {
+    if (!this.#select) return;
+
+    // 属性の転送
+    this.#syncSelectAttributes();
+
+    // option/optgroup の複製
+    this.#syncOptions();
+
+    // イベントリスナー
+    this.#select.addEventListener('input', this.#handleInput);
+    this.#select.addEventListener('change', this.#handleChange);
+    this.#select.addEventListener('keydown', this.#handleAriaDisabledKeydown);
+    this.#select.addEventListener('mousedown', this.#handleAriaDisabledMouseDown);
+  }
+
+  #initSlots(): void {
+    setupSlotChangeListeners(
+      {
+        label: this.#labelSlot,
+        support: this.#supportSlot,
+        error: this.#errorSlot,
+      },
+      {
+        onLabelChange: () =>
+          updateLabelFallback(this.#labelSlot, this.#labelFallback, this.getAttribute('label')),
+        onSupportChange: () => {
+          updateSupportFallback(
+            this.#supportSlot,
+            this.#supportText,
+            this.#supportFallback,
+            this.getAttribute('support-text')
+          );
+          this.#updateAriaDescribedBy();
+        },
+        onErrorChange: () => {
+          updateErrorFallback(
+            this.#errorSlot,
+            this.#errorText,
+            this.#errorFallback,
+            this.getAttribute('error-text'),
+            this.hasAttribute('error')
+          );
+          this.#updateAriaDescribedBy();
+        },
+      }
+    );
+    updateRequirement(this.#requirement, this.hasAttribute('required'), false);
+  }
+
+  #setupFormValidation(): void {
+    // 付け替えを許容（auto-validate属性の動的変更に追従）
+    this.#formValidation?.cleanup();
+    this.#formValidation = setupFormValidation(
+      this,
+      this._internals,
+      'auto-validate',
+      this.#handleFormSubmit
+    );
+  }
+
+  #setupOptionsObserver(): void {
+    this.#optionsObserver?.disconnect();
+    this.#optionsObserver = new MutationObserver((mutations) => {
+      if (!mutations.some((mutation) => this.#shouldSyncOptionsFromMutation(mutation))) return;
+      this.#syncOptions();
+    });
+
+    this.#optionsObserver.observe(this, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      characterData: true,
+    });
+  }
+
+  #shouldSyncOptionsFromMutation(mutation: MutationRecord): boolean {
+    switch (mutation.type) {
+      case 'childList':
+        return true;
+      case 'attributes': {
+        const el = mutation.target;
+        if (!(el instanceof Element)) return false;
+        return el.tagName === 'OPTION' || el.tagName === 'OPTGROUP';
+      }
+      case 'characterData': {
+        const parent = (mutation.target as CharacterData).parentElement;
+        if (!parent) return false;
+        return parent.tagName === 'OPTION' || parent.tagName === 'OPTGROUP';
+      }
+      default:
+        return false;
+    }
+  }
+
+  #parseSizeAttr(): { variant: 'sm' | 'md' | 'lg'; width: string | null } {
+    const raw = this.getAttribute('size');
+    const tokens = raw ? raw.trim().split(/\s+/).filter(Boolean) : [];
+
+    let variant: 'sm' | 'md' | 'lg' | null = null;
+    let width: string | null = null;
+    const isVariantToken = (token: string): token is 'sm' | 'md' | 'lg' =>
+      token === 'sm' || token === 'md' || token === 'lg';
+    for (const token of tokens) {
+      if (isVariantToken(token)) {
+        if (variant === null) {
+          variant = token;
+          if (width !== null) break;
+        }
+        continue;
+      }
+      if (width !== null) continue;
+
+      if (token === 'full') {
+        width = '100%';
+        if (variant !== null) break;
+        continue;
+      }
+      if (token === 'fit' || token === 'fit-content') {
+        width = 'fit-content';
+        if (variant !== null) break;
+        continue;
+      }
+      if (token === 'auto' || token === 'min-content' || token === 'max-content') {
+        width = token;
+        if (variant !== null) break;
+        continue;
+      }
+
+      // 数値のみは px として扱う（例: "256" → "256px"）
+      if (/^\d+(\.\d+)?$/.test(token)) {
+        width = `${token}px`;
+        if (variant !== null) break;
+        continue;
+      }
+
+      // カスタム値 (200px, 20ch, 50% など)
+      if (/^\d+(\.\d+)?(px|ch|em|rem|vw|%)$/.test(token)) {
+        width = token;
+        if (variant !== null) break;
+        continue;
+      }
+    }
+
+    return { variant: variant ?? 'md', width };
+  }
+
+  #syncSelectAttributes(): void {
+    if (!this.#select) return;
+
+    // name属性の転送
+    const name = this.getAttribute('name');
+    if (name !== null) {
+      this.#select.setAttribute('name', name);
+    } else {
+      this.#select.removeAttribute('name');
+    }
+
+    // disabled属性（ネイティブ）
+    this.#select.disabled = this.#formDisabled || this.hasAttribute('disabled');
+
+    // aria-disabled（無効相当: Tab移動は許容、操作は抑止）
+    if (this.#isAriaDisabled()) {
+      this.#select.setAttribute('aria-disabled', 'true');
+    } else {
+      this.#select.removeAttribute('aria-disabled');
+    }
+
+    // required は内部selectに転送しない（ネイティブバリデーションを使わず、カスタムバリデーションで制御）
+    // 代わりに aria-required を設定してアクセシビリティを維持
+    if (this.hasAttribute('required')) {
+      this.#select.setAttribute('aria-required', 'true');
+    } else {
+      this.#select.removeAttribute('aria-required');
+    }
+
+    // error状態
+    this.#select.setAttribute('aria-invalid', this.hasAttribute('error') ? 'true' : 'false');
+
+    // size（サイズバリアント + 幅指定）
+    const { variant, width } = this.#parseSizeAttr();
+    this.#select.setAttribute('data-size', variant);
+    if (width) {
+      this.style.setProperty('--dads-select-width', width);
+    } else {
+      this.style.removeProperty('--dads-select-width');
+    }
+  }
+
+  #getLightDomOptionElements(): Array<HTMLOptionElement | HTMLOptGroupElement> {
+    const out: Array<HTMLOptionElement | HTMLOptGroupElement> = [];
+
+    for (const el of Array.from(this.children)) {
+      if (el instanceof HTMLOptionElement || el instanceof HTMLOptGroupElement) {
+        out.push(el);
+      }
+    }
+
+    return out;
+  }
+
+  #syncOptions(): void {
+    if (!this.#select) return;
+
+    const desiredValueAttr = this.getAttribute('value');
+    const preserveValue = desiredValueAttr ?? (this.#select.options.length > 0 ? this.#select.value : null);
+
+    const clones = this.#getLightDomOptionElements().map((el) => el.cloneNode(true));
+    this.#select.replaceChildren(...clones);
+
+    // 値の復元（存在しない場合はselect側のデフォルトにフォールバック）
+    if (preserveValue !== null) this.#select.value = preserveValue;
+
+    this._internals.setFormValue(this.#select.value);
+  }
+
+  #updateAriaDescribedBy(): void {
+    const supportVisible = this.#supportText?.style.display !== 'none';
+    updateAriaDescribedBy(this.#select, supportVisible, this.hasAttribute('error'));
+  }
+
+  #handleInput = (): void => {
+    if (this.#select) {
+      this._internals.setFormValue(this.#select.value);
+    }
+
+    if (this.hasAttribute('auto-validate') && this.#validationErrorType) {
+      this.#clearValidationError();
+    }
+
+    this.emitEvent('dads-input', { value: this.value });
+  };
+
+  #handleChange = (): void => {
+    this.emitEvent('dads-change', { value: this.value });
+  };
+
+  #handleAriaDisabledKeydown = (e: KeyboardEvent): void => {
+    if (!this.#isAriaDisabled()) return;
+    if (e.code === 'Tab') return;
+    e.preventDefault();
+  };
+
+  #handleAriaDisabledMouseDown = (e: MouseEvent): void => {
+    if (!this.#isAriaDisabled()) return;
+    e.preventDefault();
+  };
+
+  #handleFormSubmit = (e: Event): void => {
+    // disabled/aria-disabledの場合はバリデーションしない（ユーザーが修正できないため）
+    if (this.hasAttribute('disabled') || this.#isAriaDisabled()) return;
+
+    const isValid = this.#validateRequired();
+    if (!isValid) {
+      e.preventDefault();
+    }
+  };
+
+  #validateRequired(): boolean {
+    if (!this.hasAttribute('required')) return true;
+    const isValid = this.value.trim().length > 0;
+    if (!isValid) {
+      this.#showValidationError('required');
+    }
+    return isValid;
+  }
+
+  #showValidationError(type: 'required'): void {
+    this.#validationErrorType = type;
+    const message = this.#getErrorMessage(type);
+    showValidationError({
+      element: this,
+      control: this.#select,
+      internals: this._internals,
+      message,
+      updateUI: (hasError) => this.#updateValidationUI(hasError),
+    });
+  }
+
+  #clearValidationError(): void {
+    if (this.#validationErrorType === null) return;
+    this.#validationErrorType = null;
+    clearValidationError(this, this._internals, (hasError) => this.#updateValidationUI(hasError));
+  }
+
+  #updateValidationUI(hasError: boolean): void {
+    updateValidationUI(
+      this.#select,
+      hasError,
+      () =>
+        updateErrorFallback(
+          this.#errorSlot,
+          this.#errorText,
+          this.#errorFallback,
+          this.getAttribute('error-text'),
+          this.hasAttribute('error')
+        ),
+      () => this.#updateAriaDescribedBy()
+    );
+  }
+
+  #getErrorMessage(type: 'required'): string {
+    return getValidationMessage(this, VALIDATION_RULES[type]);
+  }
+
+  #isAriaDisabled(): boolean {
+    const v = this.getAttribute('aria-disabled');
+    if (v === null) return false;
+    if (v.trim().toLowerCase() === 'false') return false;
+    return true;
+  }
+
+  attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null): void {
+    super.attributeChangedCallback(name, oldValue, newValue);
+
+    if (!this.#select) return;
+
+    switch (name) {
+      case 'label':
+        updateLabelFallback(this.#labelSlot, this.#labelFallback, this.getAttribute('label'));
+        break;
+      case 'support-text':
+        updateSupportFallback(
+          this.#supportSlot,
+          this.#supportText,
+          this.#supportFallback,
+          this.getAttribute('support-text')
+        );
+        this.#updateAriaDescribedBy();
+        break;
+      case 'required':
+        updateRequirement(this.#requirement, this.hasAttribute('required'), false);
+        if (this.hasAttribute('required')) {
+          this.#select.setAttribute('aria-required', 'true');
+        } else {
+          this.#select.removeAttribute('aria-required');
+        }
+        break;
+      case 'error':
+      case 'error-text':
+        updateErrorFallback(
+          this.#errorSlot,
+          this.#errorText,
+          this.#errorFallback,
+          this.getAttribute('error-text'),
+          this.hasAttribute('error')
+        );
+        this.#updateAriaDescribedBy();
+        this.#select.setAttribute('aria-invalid', this.hasAttribute('error') ? 'true' : 'false');
+        break;
+      case 'disabled':
+      case 'name':
+      case 'size':
+      case 'aria-disabled':
+        this.#syncSelectAttributes();
+        break;
+      case 'auto-validate':
+        this.#setupFormValidation();
+        break;
+      case 'value':
+        if (newValue !== null) {
+          this.value = newValue;
+        }
+        break;
+    }
+  }
+
+  // Public API
+  get value(): string {
+    return this.#select?.value ?? '';
+  }
+
+  set value(v: string) {
+    if (!this.#select) return;
+    this.#select.value = v;
+    this._internals.setFormValue(this.#select.value);
+  }
+
+  // Form callbacks
+  formResetCallback(): void {
+    const defaultValue = this.getAttribute('value') ?? '';
+    this.value = defaultValue;
+  }
+
+  formStateRestoreCallback(state: unknown, _mode: unknown): void {
+    if (state !== null && typeof state === 'string') {
+      this.value = state;
+    }
+  }
+
+  formDisabledCallback(disabled: boolean): void {
+    super.formDisabledCallback(disabled);
+    this.#formDisabled = disabled;
+    this.#syncSelectAttributes();
+  }
+
+  // Focus delegation
+  focus(options?: FocusOptions): void {
+    this.#select?.focus(options);
+  }
+
+  blur(): void {
+    this.#select?.blur();
+  }
+}
+
+// フォーム要素の標準動作を適用
+applyStandardFormElementBehavior(DadsSelect, 'value', 'value');

--- a/packages/components/textarea/textarea-styles.ts
+++ b/packages/components/textarea/textarea-styles.ts
@@ -55,7 +55,7 @@ export const textareaStyles = css`
   /* ========== サポートテキスト ========== */
   [part="support-text"] {
     margin: 0;
-    font-size: var(--font-size-14);
+    font-size: var(--font-size-16);
     color: var(--dads-textarea-support-color);
     line-height: var(--line-height-150);
   }
@@ -140,7 +140,7 @@ export const textareaStyles = css`
   /* ========== 文字数カウンター ========== */
   [part="counter"] {
     display: block;
-    font-size: var(--font-size-14);
+    font-size: var(--font-size-16);
     color: var(--dads-textarea-counter-color);
     line-height: var(--line-height-130);
     min-height: 1.5em;
@@ -159,7 +159,7 @@ export const textareaStyles = css`
 
   /* ========== エラーテキスト ========== */
   [part="error-text"] {
-    font-size: var(--font-size-14);
+    font-size: var(--font-size-16);
     color: var(--dads-textarea-error-color);
     line-height: var(--line-height-150);
   }

--- a/packages/components/textarea/textarea-tokens.ts
+++ b/packages/components/textarea/textarea-tokens.ts
@@ -20,9 +20,9 @@ const textareaSemanticTokensText = `
     --textarea-label-size-lg: var(--font-size-18, 1.125rem);
 
     /* テキストサイズ */
-    --textarea-font-size-sm: var(--font-size-14, 0.875rem);
+    --textarea-font-size-sm: var(--font-size-16, 1rem);
     --textarea-font-size-md: var(--font-size-16, 1rem);
-    --textarea-font-size-lg: var(--font-size-18, 1.125rem);
+    --textarea-font-size-lg: var(--font-size-16, 1rem);
 
     /* 背景色 */
     --textarea-bg: var(--color-neutral-white, #ffffff);
@@ -134,13 +134,11 @@ const textareaLocalTokensText = `
   /* サイズバリアント */
   :host([size="sm"]) {
     --dads-textarea-label-size: var(--textarea-label-size-sm);
-    --dads-textarea-font-size: var(--textarea-font-size-sm);
     --dads-textarea-min-height: var(--textarea-min-height-sm);
   }
 
   :host([size="lg"]) {
     --dads-textarea-label-size: var(--textarea-label-size-lg);
-    --dads-textarea-font-size: var(--textarea-font-size-lg);
     --dads-textarea-min-height: var(--textarea-min-height-lg);
   }
 

--- a/packages/utils/form-component-helpers.ts
+++ b/packages/utils/form-component-helpers.ts
@@ -218,7 +218,7 @@ export function updateRequirement(
  * @param updateAriaFn - aria-describedby更新関数
  */
 export function updateValidationUI(
-  control: HTMLInputElement | HTMLTextAreaElement | null,
+  control: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement | null,
   hasError: boolean,
   updateErrorFn: () => void,
   updateAriaFn: () => void
@@ -236,8 +236,8 @@ export function updateValidationUI(
 export interface ShowValidationErrorOptions {
   /** ホスト要素 */
   element: HTMLElement;
-  /** 内部input/textarea要素 */
-  control: HTMLInputElement | HTMLTextAreaElement | null;
+  /** 内部input/textarea/select要素 */
+  control: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement | null;
   /** ElementInternalsインスタンス */
   internals: ElementInternals;
   /** エラーメッセージ */
@@ -306,7 +306,7 @@ export interface AriaDescribedByConfig {
  * @param config - ID設定
  */
 export function updateAriaDescribedBy(
-  control: HTMLInputElement | HTMLTextAreaElement | null,
+  control: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement | null,
   supportVisible: boolean,
   errorVisible: boolean,
   counterVisible: boolean = false,

--- a/src/demos.ts
+++ b/src/demos.ts
@@ -1661,6 +1661,229 @@ export const demos = {
     </div>
   `,
 
+  select: () => `
+    <div style="padding: 40px; max-width: 1100px; margin: 0 auto;">
+      <h2 style="font-size: 28px; margin-bottom: 20px; color: #333;">セレクトボックス</h2>
+      <p style="color: #666; margin-bottom: 40px;">
+        デジタル庁デザインシステム（DADS）HTML版 select.css 相当をShadow DOM向けに移植したWeb Components版です。
+      </p>
+
+      ${annotationToggleUI()}
+      ${annotationToggleScript()}
+
+      <!-- アクセシビリティ注釈 -->
+      <section style="margin-bottom: 40px;">
+        <h3 style="font-size: 20px; margin-bottom: 16px; color: #333;">アクセシビリティ注釈（a11y-annotate）</h3>
+        <p style="font-size: 14px; color: #666; margin-bottom: 16px;">
+          ※ 右側パネルに仕様メモ、左側にターゲット要素のコールアウトが表示されます。
+        </p>
+        <a11y-annotate target-selector="dads-select">
+          <div style="display: grid; place-content: center; padding: 60px 0;">
+            <dads-select
+              label="東京23区"
+              support-text="該当する区を選択してください。"
+              required
+              size="md 420"
+            >
+              <option value="">選択してください</option>
+              <option value="1">足立区</option>
+              <option value="2">荒川区</option>
+              <option value="3">板橋区</option>
+              <option value="4">江戸川区</option>
+            </dads-select>
+          </div>
+        </a11y-annotate>
+      </section>
+
+      <!-- 基本 -->
+      <section style="margin-bottom: 40px;">
+        <h3 style="font-size: 20px; margin-bottom: 20px; color: #333;">基本</h3>
+        <div style="max-width: 420px;">
+          <dads-select label="都道府県" support-text="お住まいの都道府県を選択してください。">
+            <option value="">選択してください</option>
+            <option value="tokyo">東京都</option>
+            <option value="kanagawa">神奈川県</option>
+            <option value="chiba">千葉県</option>
+            <option value="saitama">埼玉県</option>
+          </dads-select>
+        </div>
+      </section>
+
+      <!-- サイズ -->
+      <section style="margin-bottom: 40px;">
+        <h3 style="font-size: 20px; margin-bottom: 20px; color: #333;">サイズ（sm / md / lg）</h3>
+        <div style="display: grid; gap: 24px; max-width: 420px;">
+          <dads-select size="sm" label="サイズ sm" support-text='size="sm"（高さ40px相当）'>
+            <option value="">選択してください</option>
+            <option value="1">選択肢1</option>
+            <option value="2">選択肢2</option>
+          </dads-select>
+
+          <dads-select size="md" label="サイズ md" support-text='size="md"（高さ48px相当）'>
+            <option value="">選択してください</option>
+            <option value="1">選択肢1</option>
+            <option value="2">選択肢2</option>
+          </dads-select>
+
+          <dads-select size="lg" label="サイズ lg" support-text='size="lg"（高さ56px相当）'>
+            <option value="">選択してください</option>
+            <option value="1">選択肢1</option>
+            <option value="2">選択肢2</option>
+          </dads-select>
+        </div>
+      </section>
+
+      <!-- optgroup -->
+      <section style="margin-bottom: 40px;">
+        <h3 style="font-size: 20px; margin-bottom: 20px; color: #333;">グルーピング（optgroup）</h3>
+        <div style="max-width: 420px;">
+          <dads-select label="種目" support-text="optgroupを含む選択肢例">
+            <option value="">選択してください</option>
+            <optgroup label="球技">
+              <option value="soccer">サッカー</option>
+              <option value="baseball">野球</option>
+              <option value="basketball">バスケットボール</option>
+            </optgroup>
+            <optgroup label="その他">
+              <option value="swim">水泳</option>
+              <option value="run">陸上</option>
+            </optgroup>
+          </dads-select>
+        </div>
+      </section>
+
+      <!-- 状態 -->
+      <section style="margin-bottom: 40px;">
+        <h3 style="font-size: 20px; margin-bottom: 20px; color: #333;">状態</h3>
+        <div style="display: grid; gap: 24px; max-width: 420px;">
+          <dads-select label="エラー" required error error-text="選択してください">
+            <option value="">選択してください</option>
+            <option value="1">選択肢1</option>
+            <option value="2">選択肢2</option>
+          </dads-select>
+
+          <dads-select label="Disabled（disabled）" disabled>
+            <option value="">選択してください</option>
+            <option value="1">選択肢1</option>
+            <option value="2">選択肢2</option>
+          </dads-select>
+
+          <dads-select label="Aria Disabled（aria-disabled）" aria-disabled="true" value="2">
+            <option value="">選択してください</option>
+            <option value="1">選択肢1</option>
+            <option value="2">選択肢2（固定）</option>
+          </dads-select>
+        </div>
+      </section>
+
+      <!-- 幅 -->
+      <section style="margin-bottom: 0;">
+        <h3 style="font-size: 20px; margin-bottom: 20px; color: #333;">幅例</h3>
+        <div style="display: grid; gap: 24px;">
+          <dads-select label="100%幅" support-text='size="md full"' size="md full">
+            <option value="">選択してください</option>
+            <option value="1">選択肢1</option>
+            <option value="2">選択肢2</option>
+          </dads-select>
+
+          <dads-select label="固定幅（256px）" support-text='size="md 256"' size="md 256">
+            <option value="">選択してください</option>
+            <option value="1">選択肢1</option>
+            <option value="2">選択肢2</option>
+          </dads-select>
+
+          <dads-select label="内容にフィット（fit-content）" support-text='size="md fit-content"' size="md fit-content">
+            <option value="">選択してください</option>
+            <option value="1">短い</option>
+            <option value="2">やや長い選択肢</option>
+          </dads-select>
+        </div>
+      </section>
+    </div>
+
+    <script type="module">
+      await Promise.all([import('dads-select'), import('dads-switch'), import('a11y-annotate')]);
+    </script>
+  `,
+
+  selectValidation: () => `
+    <div style="padding: 40px; max-width: 600px; margin: 0 auto;">
+      <h2 style="font-size: 24px; margin-bottom: 20px; color: #333;">Select Validation Test</h2>
+      <p style="color: #666; margin-bottom: 30px;">
+        auto-validate属性による必須バリデーション機能のテスト（セレクトボックス）
+      </p>
+
+      <form id="select-validation-form" novalidate>
+        <!-- 必須バリデーション -->
+        <section style="margin-bottom: 32px;">
+          <h3 style="font-size: 16px; margin-bottom: 12px; color: #555;">必須バリデーション</h3>
+          <dads-select
+            label="必須項目"
+            support-text="空のまま送信するとエラー表示されます"
+            required
+            auto-validate
+          >
+            <option value="">選択してください</option>
+            <option value="1">選択肢1</option>
+            <option value="2">選択肢2</option>
+            <option value="3">選択肢3</option>
+          </dads-select>
+        </section>
+
+        <!-- カスタムエラーメッセージ -->
+        <section style="margin-bottom: 32px;">
+          <h3 style="font-size: 16px; margin-bottom: 12px; color: #555;">カスタムエラーメッセージ（required-error）</h3>
+          <dads-select
+            label="お住まいの地域"
+            support-text="required-errorスロットでメッセージをカスタマイズ"
+            required
+            auto-validate
+          >
+            <option value="">選択してください</option>
+            <option value="east">東日本</option>
+            <option value="west">西日本</option>
+            <span slot="required-error">地域を選択してください（カスタム）</span>
+          </dads-select>
+        </section>
+
+        <!-- バリデーション無効（比較用） -->
+        <section style="margin-bottom: 32px;">
+          <h3 style="font-size: 16px; margin-bottom: 12px; color: #555;">バリデーション無効（比較用）</h3>
+          <dads-select
+            label="auto-validateなし"
+            support-text="auto-validate属性がないため、バリデーションされません"
+            required
+          >
+            <option value="">選択してください</option>
+            <option value="1">選択肢1</option>
+            <option value="2">選択肢2</option>
+          </dads-select>
+        </section>
+
+        <div style="display: flex; gap: 12px; justify-content: flex-end; margin-top: 24px;">
+          <dads-button type="reset">リセット</dads-button>
+          <dads-button type="submit" variant="solid">送信</dads-button>
+        </div>
+      </form>
+
+      <div style="margin-top: 40px; background: #fff3cd; padding: 20px; border-radius: 8px; border-left: 4px solid #ffc107;">
+        <h3 style="color: #856404; margin-bottom: 10px;">テスト手順</h3>
+        <ol style="color: #856404; line-height: 1.8; padding-left: 20px;">
+          <li>「必須項目」を未選択のまま「送信」ボタン → エラー表示</li>
+          <li>選択肢を選んで再送信 → エラークリア</li>
+          <li>カスタムメッセージの表示確認（required-errorスロット）</li>
+          <li>auto-validateなしのフィールドでは、バリデーションが発生しないことを確認</li>
+        </ol>
+      </div>
+    </div>
+
+    <script type="module">
+      await Promise.all([import('dads-select'), import('dads-button')]);
+      const form = document.getElementById('select-validation-form');
+      if (form) form.addEventListener('submit', (e) => e.preventDefault());
+    </script>
+  `,
+
   switch: () => `
     <div style="padding: 40px; max-width: 1280px; margin: 0 auto;">
       <h2 style="font-size: 28px; margin-bottom: 20px; color: #333;">スイッチコンポーネント</h2>

--- a/viewer.html
+++ b/viewer.html
@@ -20,6 +20,7 @@
       "dads-blockquote": "/@components/dads/blockquote.js",
       "dads-text": "/@components/dads/text.js",
       "dads-input-text": "/@components/dads/input-text.js",
+      "dads-select": "/@components/dads/select.js",
       "dads-date-picker": "/@components/dads/date-picker.js",
       "dads-calendar": "/@components/dads/calendar.js",
       "dads-switch": "/@components/dads/switch.js",
@@ -226,6 +227,8 @@
             <option value="datePicker">日付ピッカー</option>
             <option value="inputText">Input Text</option>
             <option value="inputTextValidation">Input Text Validation</option>
+            <option value="select">Select</option>
+            <option value="selectValidation">Select Validation</option>
             <option value="textarea">Textarea</option>
             <option value="textareaValidation">Textarea Validation</option>
             <option value="switch">Switch</option>
@@ -364,6 +367,7 @@
     const componentAdapters = [
       '/@components/dads/textarea.js',
       '/@components/dads/input-text.js',
+      '/@components/dads/select.js',
       '/@components/dads/calendar.js',
       '/@components/dads/date-picker.js',
       '/@components/dads/checkbox.js',


### PR DESCRIPTION
Adds a DADS-based <dads-select> component (native <select>) with tokens/styles, Storybook story, and tests. Wires it into exports, autoload adapter, and viewer demos including validation examples. Normalizes support/error/counter text sizes to 16px across form components.