### PR TITLE
fix(pages): load CEM reliably for a11y-annotate

### DIFF
--- a/docs/accessibility-annotations.md
+++ b/docs/accessibility-annotations.md
@@ -56,6 +56,23 @@ Design System コンポーネントをドキュメンテーション用途で「
 1. `docs/knowledge/a11y-annotations.json` を更新
 2. `npm run cem:analyze` を実行して `custom-elements.json` に反映
 
+## CEM のロード（特に GitHub Pages）
+
+`a11y-annotate` は注釈が有効なとき、ランタイムで CEM（`custom-elements.json`）を読み込みます。
+
+- 取得URLは **`document.baseURI` 基準の相対**（`./custom-elements.json`）で解決します（Project Pages の `/<repo>/` 配下でも動くため）
+- 非ブラウザ環境などで `document` が無い場合はフォールバックとして `/custom-elements.json` を参照します
+
+### トラブルシューティング（症状: 404 → 重くなる/固まる）
+
+DevTools Console/Network で `custom-elements.json` が 404 の場合、注釈のロードに失敗して表示できません。
+
+確認ポイント:
+1. `npm run pages:build` 後に `dist-pages/custom-elements.json` が存在する
+2. `node scripts/check-pages-output.cjs` が `OK: custom-elements.json` になる
+
+※ CEM 取得に失敗しても `a11y-annotate` が無限 refresh しないようにガードしていますが、そもそも 404 を消すのが正です。
+
 ### コールアウトターゲットの指定
 
 `callouts[].target` は「どの要素に紐付けるか」を指定します。

--- a/docs/knowledge/component-skeleton.md
+++ b/docs/knowledge/component-skeleton.md
@@ -187,6 +187,7 @@ export default DadsComponent;
 **注意**
 - `a11y-annotate` は dev専用で、`custom-elements.json`（CEM）から注釈を読み取る。
 - viewerで表示する場合は `?a11y=1` を付与する。
+- GitHub Pages（Project Pages）では `custom-elements.json` が `/<repo>/custom-elements.json` として配信される必要がある（`pages:build` の成果物に同梱されること）。
 - デモ実装パターンは `docs/knowledge/a11y-annotate-demo-patterns.md` を参照。
 
 ---

--- a/docs/plans/gh-pages-viewer.md
+++ b/docs/plans/gh-pages-viewer.md
@@ -35,7 +35,7 @@
 - `?component=...` の切り替えが動作する
 - Autoloader によるロードが動作し、各コンポーネントが表示される
 - 404 が発生しない（少なくとも以下）
-  - `core/*.js`, `utils/*.js`, `styles/*.js`, `components/**`, `@components/**`, `config.js`, `src/demos.js`
+  - `core/*.js`, `utils/*.js`, `styles/*.js`, `components/**`, `@components/**`, `config.js`, `src/demos.js`, `custom-elements.json`
 - 初回は Service Worker を無効化してもよい（= SW 起因の 404 を避ける）
 
 ## 方針（決定事項）
@@ -51,6 +51,7 @@
 ```
 dist-pages/
 ├── index.html
+├── custom-elements.json
 ├── config.js
 ├── core/
 │   ├── web-components.js
@@ -97,6 +98,7 @@ dist-pages/
 
 ### 3) トランスパイル対象と配置マッピング
 
+- `custom-elements.json` → `dist-pages/custom-elements.json`
 - `packages/config.ts` → `dist-pages/config.js`
 - `packages/core/**/*.ts` → `dist-pages/core/**/*.js`
 - `packages/utils/**/*.ts` → `dist-pages/utils/**/*.js`
@@ -147,6 +149,8 @@ dist-pages/
   - 対策: `index.html` 生成時に、import map / preload / dynamic import 文字列を確実に `./` に統一
 - **Service Worker が absolute path をキャッシュしようとして 404**
   - 対策: フェーズ1では SW を無効化してリスクを切り離す
+- **`custom-elements.json` が配信されないと a11y-annotate（注釈）が動かない**
+  - 対策: `pages:build` で `dist-pages/custom-elements.json` を同梱し、`scripts/check-pages-output.cjs` で存在/JSON妥当性をチェックする
 
 ## フェーズ2（SW 有効化 / パフォーマンス最適化）
 

--- a/packages/components/annotate/annotate.test.ts
+++ b/packages/components/annotate/annotate.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { waitFor } from '@testing-library/dom';
 import {
   cleanup,
@@ -39,6 +39,48 @@ function waitForDoubleRaf(): Promise<void> {
 describe('DadsAnnotate', () => {
   afterEach(() => {
     cleanup();
+    try {
+      window.localStorage.removeItem('dads:a11y');
+    } catch {
+      // ignore
+    }
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('CEMロード失敗時でも無限refreshしない', async () => {
+    const { defineDefaultAnnotate } = await import('./annotate-define');
+    defineDefaultAnnotate();
+
+    window.localStorage.setItem('dads:a11y', '1');
+
+    let microtaskCalls = 0;
+    const origQueueMicrotask = globalThis.queueMicrotask;
+    vi.stubGlobal('queueMicrotask', (cb: VoidFunction) => {
+      microtaskCalls += 1;
+      return origQueueMicrotask(cb);
+    });
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 404, json: async () => ({}) }) as unknown as Response),
+    );
+
+    const el = renderWebComponent(`
+      <a11y-annotate>
+        <div id="target">Target</div>
+      </a11y-annotate>
+    `);
+
+    await waitForComponent('a11y-annotate');
+    expect(el).toBeInTheDocument();
+
+    // microtaskが連鎖している場合、短時間で呼び出し回数が増え続ける
+    await new Promise((r) => setTimeout(r, 50));
+    expect(microtaskCalls).toBeLessThan(20);
+
+    // CEM取得は1回に抑えられる（失敗しても再試行ループしない）
+    expect(fetch).toHaveBeenCalledTimes(1);
   });
 
   it('ラップした要素を表示し、6カテゴリの枠を出す', async () => {

--- a/packages/components/annotate/annotate.ts
+++ b/packages/components/annotate/annotate.ts
@@ -95,12 +95,21 @@ function getAriaAttrs(el: Element): readonly [string, string][] {
   return out;
 }
 
-const CEM_URL = '/custom-elements.json';
+const CEM_URL_FALLBACK = '/custom-elements.json';
 const A11Y_QUERY_PARAM = 'a11y';
 const A11Y_STORAGE_KEY = 'dads:a11y';
 
 let cemAnnotations: Map<string, A11yAnnotations> | null = null;
 let cemAnnotationsPromise: Promise<Map<string, A11yAnnotations>> | null = null;
+
+function resolveCemUrl(): string {
+  try {
+    if (typeof document !== 'undefined') return new URL('custom-elements.json', document.baseURI).toString();
+  } catch {
+    // fall through
+  }
+  return CEM_URL_FALLBACK;
+}
 
 function isA11yAnnotationsEnabled(): boolean {
   if (typeof window === 'undefined') return false;
@@ -135,7 +144,8 @@ function parseCemAnnotations(manifest: CemManifest | null | undefined): Map<stri
 function loadCemAnnotations(): Promise<Map<string, A11yAnnotations>> {
   if (cemAnnotations) return Promise.resolve(cemAnnotations);
   if (!cemAnnotationsPromise) {
-    cemAnnotationsPromise = fetch(CEM_URL)
+    const cemUrl = resolveCemUrl();
+    cemAnnotationsPromise = fetch(cemUrl)
       .then((res) => {
         if (!res.ok) throw new Error(`Failed to load CEM: ${res.status}`);
         return res.json();
@@ -163,7 +173,11 @@ function readAnnotations(
     const tagName = el.localName;
     const spec = cemAnnotations?.get(tagName) ?? null;
     if (spec) return spec;
-    void loadCemAnnotations().then(() => onCemLoaded?.());
+    // CEMが未ロードのときだけロードし、ロード完了後に再描画を予約する。
+    // 既にロード済み（空Map=取得失敗/未収載含む）の場合は無限refreshを避けるため予約しない。
+    if (cemAnnotations === null) {
+      void loadCemAnnotations().then(() => onCemLoaded?.());
+    }
   }
 
   const inst = el.a11yAnnotations;

--- a/scripts/build-pages.cjs
+++ b/scripts/build-pages.cjs
@@ -157,6 +157,12 @@ async function buildIndexHtml() {
   await fs.writeFile(destHtmlPath, html, 'utf8');
 }
 
+async function copyCustomElementsManifest() {
+  const srcPath = path.join(projectRoot, 'custom-elements.json');
+  const destPath = path.join(outDir, 'custom-elements.json');
+  await fs.copyFile(srcPath, destPath);
+}
+
 async function cleanOutDir() {
   await fs.rm(outDir, { recursive: true, force: true });
   await ensureDir(outDir);
@@ -167,6 +173,7 @@ async function main() {
 
   await cleanOutDir();
   await buildIndexHtml();
+  await copyCustomElementsManifest();
 
   await transpileFile(path.join(projectRoot, 'packages/config.ts'), path.join(outDir, 'config.js'));
 

--- a/scripts/check-pages-output.cjs
+++ b/scripts/check-pages-output.cjs
@@ -18,3 +18,20 @@ if (html.includes('Average Case UI')) {
 
 console.log('[pages] OK: Viewer');
 
+const outDir = path.dirname(indexHtmlPath);
+const cemPath = path.join(outDir, 'custom-elements.json');
+if (!fs.existsSync(cemPath)) {
+  console.error(`[pages] Missing Custom Elements Manifest: ${cemPath}`);
+  process.exit(1);
+}
+
+try {
+  const cemRaw = fs.readFileSync(cemPath, 'utf8');
+  JSON.parse(cemRaw);
+} catch (error) {
+  console.error(`[pages] Invalid Custom Elements Manifest JSON: ${cemPath}`);
+  console.error(error);
+  process.exit(1);
+}
+
+console.log('[pages] OK: custom-elements.json');


### PR DESCRIPTION
## 背景
GitHub Pages（Project Pages）で `a11y-annotate` が `custom-elements.json` を読めず（404）、注釈が表示できない・ページが重くなる/固まるケースがありました。

## 変更
- CEM取得URLを `document.baseURI` 基準で相対解決（Project Pages配下でもOK）
- CEM取得失敗/未収載時に refresh が無限に回らないようガード
- `pages:build` の成果物 `dist-pages/` に `custom-elements.json` を同梱
- `scripts/check-pages-output.cjs` で CEM の存在/JSON妥当性をチェック
- 回帰テスト追加（CEM 404でもハングしない）
- 関連ドキュメントに再発防止ナレッジを追記

## 確認
- `npm run type-check`
- `npm run test:run -- packages/components/annotate/annotate.test.ts`
- `npm run pages:build` + `node scripts/check-pages-output.cjs`

## 影響
- 公開API変更なし
