### PR TITLE
fix: tableControl demo 404 on GitHub Pages

### DIFF
--- a/docs/knowledge/learnings.md
+++ b/docs/knowledge/learnings.md
@@ -1339,4 +1339,33 @@ dads-card.card-example-1::part(main) {
 
 ---
 
+## [2026-02-09] Project Pagesで `src/demos` 絶対パスが404になる問題と予防策
+**タグ**: #webcomponents #workflow #debug #architecture
+
+### 概要
+`tableControl` デモ内の dynamic import が `import('/src/demos/...')` になっていたため、GitHub Pages（Project Pages: `/<repo>/`）で `https://<user>.github.io/src/demos/...` に解決されて 404 になり、MVC デモの初期化が失敗した。
+
+### 詳細
+#### 症状
+- `table-control-mvc.js` / `table-control-municipal-mvc.js` / `table-control-preset-mvc.js` の取得が 404
+- `dads-table-control` は読み込まれるが、データ連動デモが表示されない
+
+#### 原因
+- 埋め込み `script type="module"` の dynamic import が先頭 `/` の絶対パスだった
+- Project Pages はルート配信ではなく `/<repo>/` 配下のため、`/src/...` はリポジトリ外を指してしまう
+
+#### 修正
+- `src/demos/showcase-table-control.ts` の import を `./src/demos/...` に変更
+- `src/demos/showcase-table-control.test.ts` で相対パス期待値へ更新し、`import('/src/demos/` を含まないことを検証
+- `tests/pages-build-viewer.test.ts` で `dist-pages/src/demos/showcase-table-control.js` に絶対パスが残っていないことを検証
+
+### 再発防止
+- レビュー観点: viewer埋め込み script の dynamic import は先頭 `/` を禁止し、`./` など `document.baseURI` 基準の相対パスを使う
+- テスト観点: Pages ビルド後の `dist-pages/src/demos/*.js` に対して絶対パス混入を検知する
+
+### 注意点
+- `deepl-input-controller` の解決失敗はリポジトリ内定義がなく、ブラウザ拡張注入などのノイズの可能性が高い。今回の主因とは切り分ける
+
+---
+
 *継続的に更新されます*

--- a/docs/rules/new-component-dod.md
+++ b/docs/rules/new-component-dod.md
@@ -72,6 +72,7 @@ export default DadsMyComponent;
 - [ ] `viewer.html` にセレクタオプション追加
 - [ ] **操作可能な API / Controls テーブル**を追加（`docs/knowledge/viewer-api-controls-table.md` を参照）
 - [ ] **新規HTMLファイルは作成禁止**
+- [ ] 埋め込み `script type="module"` の dynamic import で先頭 `/` の絶対パスを使わない（`./` など `document.baseURI` 基準の相対パスを使う）
 - [ ] `placeholder` 属性は使用禁止（ネイティブ `<input>` 含む）。ヒントは `support-text` / `aria-describedby` などで提供する
 
 **参照**: [コンポーネント雛形](../knowledge/component-skeleton.md)
@@ -209,6 +210,7 @@ PRコメントや自己レビュー用：
 - [ ] `src/demos.ts` にデモ追加
 - [ ] `src/demos.ts` の説明ページに **Usage（HTML）コードブロック（`<dads-code-block>`）** を追加
 - [ ] `src/demos.ts` に **操作可能な API / Controls テーブル**を追加（`docs/knowledge/viewer-api-controls-table.md` を参照）
+- [ ] 埋め込み `script type="module"` の dynamic import で先頭 `/` の絶対パスを使わない（`./` など `document.baseURI` 基準の相対パスを使う）
 - [ ] `placeholder` 属性は使用禁止（ネイティブ `<input>` 含む）。ヒントは `support-text` / `aria-describedby` などで提供する
 - [ ] `viewer.html` にセレクタ追加
 - [ ] `packages/components/<componentId>/<componentId>-define.ts` を用意（例外は `registry/overrides.json` に理由つきで明記）

--- a/src/demos/showcase-table-control.test.ts
+++ b/src/demos/showcase-table-control.test.ts
@@ -142,9 +142,10 @@ describe('showcase-table-control demo', () => {
     expect(html).toContain("import('dads-chip-label')");
     expect(html).toContain("import('dads-menu-list-box')");
     expect(html).toContain("import('dads-code-block')");
-    expect(html).toContain('/src/demos/table-control-municipal-mvc.js');
+    expect(html).toContain('./src/demos/table-control-municipal-mvc.js');
     expect(html).toContain('mountTableControlMunicipalDemo');
-    expect(html).toContain('/src/demos/table-control-preset-mvc.js');
+    expect(html).toContain('./src/demos/table-control-preset-mvc.js');
     expect(html).toContain('mountTableControlPresetDemo');
+    expect(html).not.toContain("import('/src/demos/");
   });
 });

--- a/src/demos/showcase-table-control.ts
+++ b/src/demos/showcase-table-control.ts
@@ -1293,9 +1293,9 @@ export const demos = {
       ]);
 
       const [{ mountTableControlDemo }, { mountTableControlMunicipalDemo }, { mountTableControlPresetDemo }] = await Promise.all([
-        import('/src/demos/table-control-mvc.js'),
-        import('/src/demos/table-control-municipal-mvc.js'),
-        import('/src/demos/table-control-preset-mvc.js'),
+        import('./src/demos/table-control-mvc.js'),
+        import('./src/demos/table-control-municipal-mvc.js'),
+        import('./src/demos/table-control-preset-mvc.js'),
       ]);
 
       const root = document.querySelector('#demo-table-control-root');

--- a/tests/pages-build-viewer.test.ts
+++ b/tests/pages-build-viewer.test.ts
@@ -14,5 +14,9 @@ describe('pages:build', () => {
 
     const html = readFileSync('dist-pages/index.html', 'utf8');
     expect(html).toContain('<title>Web Components Viewer');
+
+    const tableControlDemoJs = readFileSync('dist-pages/src/demos/showcase-table-control.js', 'utf8');
+    expect(tableControlDemoJs).not.toContain("import('/src/demos/");
+    expect(tableControlDemoJs).toContain("import('./src/demos/");
   });
 });


### PR DESCRIPTION
## Summary
- Fix table-control demo dynamic imports to use baseURI-relative paths (`./src/demos/...`) instead of root-absolute paths (`/src/demos/...`).
- Update `showcase-table-control` unit test to assert relative import paths and guard against `/src/demos` absolute imports.
- Add Pages build guard test to validate no absolute `/src/demos` imports remain in `dist-pages/src/demos/showcase-table-control.js`.
- Add DoD rule to prohibit root-absolute dynamic imports in embedded module scripts.
- Add a knowledge entry documenting the incident, root cause, fix, and prevention.

## Root Cause
`src/demos/showcase-table-control.ts` used `import('/src/demos/...')`, which breaks on GitHub Project Pages (`/<repo>/`) and caused 404s for MVC demo modules.

## Verification
- `npm run agents:verify`
- `npm run test:run -- src/demos/showcase-table-control.test.ts`
- `npm run test:run -- tests/pages-build-viewer.test.ts`
- `npm run pages:build && node scripts/check-pages-output.cjs`
