### PR TITLE
feat: add dads-progress component

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -31509,6 +31509,1066 @@
     },
     {
       "kind": "javascript-module",
+      "path": "./packages/components/progress/progress.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "Progress コンポーネント",
+          "name": "DadsProgress",
+          "cssProperties": [
+            {
+              "description": "トラック色",
+              "name": "--dads-progress-track-color"
+            },
+            {
+              "description": "フィル色",
+              "name": "--dads-progress-fill-color"
+            },
+            {
+              "description": "linear/segmented 高さ",
+              "name": "--dads-progress-height"
+            },
+            {
+              "description": "角丸",
+              "name": "--dads-progress-radius"
+            },
+            {
+              "description": "circular 直径",
+              "name": "--dads-progress-size"
+            },
+            {
+              "description": "circular 線幅",
+              "name": "--dads-progress-stroke-width"
+            },
+            {
+              "description": "segmented の間隔",
+              "name": "--dads-progress-segment-gap"
+            },
+            {
+              "description": "アニメーション時間",
+              "name": "--dads-progress-animation-duration"
+            },
+            {
+              "description": "ラベル色",
+              "name": "--dads-progress-label-color"
+            },
+            {
+              "description": "値色",
+              "name": "--dads-progress-value-color"
+            }
+          ],
+          "cssParts": [
+            {
+              "description": "進捗本体（progressbar）",
+              "name": "bar"
+            },
+            {
+              "description": "circular フィル",
+              "name": "circular-fill"
+            },
+            {
+              "description": "circular SVG",
+              "name": "circular-svg"
+            },
+            {
+              "description": "circular トラック",
+              "name": "circular-track"
+            },
+            {
+              "description": "linear のフィル",
+              "name": "fill"
+            },
+            {
+              "description": "ラベル領域",
+              "name": "label"
+            },
+            {
+              "description": "ルート",
+              "name": "root"
+            },
+            {
+              "description": "segmented の1区画",
+              "name": "segment"
+            },
+            {
+              "description": "segmented の塗り",
+              "name": "segment-fill"
+            },
+            {
+              "description": "segmented ラッパー",
+              "name": "segments"
+            },
+            {
+              "description": "live領域（visually-hidden）",
+              "name": "status"
+            },
+            {
+              "description": "linear のトラック",
+              "name": "track"
+            },
+            {
+              "description": "可視値テキスト領域",
+              "name": "value-text"
+            }
+          ],
+          "slots": [
+            {
+              "description": "可視ラベル",
+              "name": "label"
+            },
+            {
+              "description": "可視値テキスト",
+              "name": "value-text"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "#def",
+              "privacy": "private",
+              "type": {
+                "text": "WebComponentDefinition | undefined"
+              },
+              "inheritedFrom": {
+                "name": "WebComponent",
+                "module": "packages/core/web-components.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#dsd",
+              "privacy": "private",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "inheritedFrom": {
+                "name": "WebComponent",
+                "module": "packages/core/web-components.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "#ensureSegmentNodes",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "HTMLElement[]"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "container",
+                  "type": {
+                    "text": "HTMLElement"
+                  }
+                },
+                {
+                  "name": "count",
+                  "type": {
+                    "text": "number"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "#ensureView",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "WebComponent",
+                "module": "packages/core/web-components.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "#finish",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "WebComponent",
+                "module": "packages/core/web-components.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#fontState",
+              "privacy": "private",
+              "type": {
+                "text": "FontObserverState"
+              },
+              "default": "{ observer: null }",
+              "inheritedFrom": {
+                "name": "TypographyWebComponent",
+                "module": "packages/core/typography/typography-web-component.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#handleSlotChange",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "#init",
+              "privacy": "private",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "inheritedFrom": {
+                "name": "WebComponent",
+                "module": "packages/core/web-components.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#labelSlot",
+              "privacy": "private",
+              "type": {
+                "text": "HTMLSlotElement | null"
+              },
+              "default": "null"
+            },
+            {
+              "kind": "field",
+              "name": "#lastStatusKey",
+              "privacy": "private",
+              "type": {
+                "text": "string | null"
+              },
+              "default": "null"
+            },
+            {
+              "kind": "field",
+              "name": "#lastStatusMessage",
+              "privacy": "private",
+              "type": {
+                "text": "string | null"
+              },
+              "default": "null"
+            },
+            {
+              "kind": "field",
+              "name": "#ready",
+              "privacy": "private",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false"
+            },
+            {
+              "kind": "method",
+              "name": "#reflectNormalizedAttributes",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "state",
+                  "type": {
+                    "text": "ProgressState"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "#render",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "#requestRender",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "#resolveState",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "ProgressState"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "#setIfDifferent",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "name",
+                  "type": {
+                    "text": "string"
+                  }
+                },
+                {
+                  "name": "next",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "#setup",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "WebComponent",
+                "module": "packages/core/web-components.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#sr",
+              "privacy": "private",
+              "type": {
+                "text": "ShadowRoot | undefined"
+              },
+              "inheritedFrom": {
+                "name": "WebComponent",
+                "module": "packages/core/web-components.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "#syncAria",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "state",
+                  "type": {
+                    "text": "ProgressState"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "#syncCircular",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "state",
+                  "type": {
+                    "text": "ProgressState"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "#syncLabelVisibility",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "#syncLinear",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "state",
+                  "type": {
+                    "text": "ProgressState"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "#syncSegments",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "state",
+                  "type": {
+                    "text": "ProgressState"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "#syncStatus",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "state",
+                  "type": {
+                    "text": "ProgressState"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "#syncVisibleValueText",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "field",
+              "name": "#valueTextSlot",
+              "privacy": "private",
+              "type": {
+                "text": "HTMLSlotElement | null"
+              },
+              "default": "null"
+            },
+            {
+              "kind": "field",
+              "name": "#view",
+              "privacy": "private",
+              "type": {
+                "text": "View | null"
+              },
+              "default": "null",
+              "inheritedFrom": {
+                "name": "WebComponent",
+                "module": "packages/core/web-components.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "compose",
+              "static": true,
+              "return": {
+                "type": {
+                  "text": "WebComponentDefinition"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "cfg",
+                  "type": {
+                    "text": "WebComponentConfig"
+                  }
+                }
+              ],
+              "inheritedFrom": {
+                "name": "WebComponent",
+                "module": "packages/core/web-components.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "composeWithTypography",
+              "static": true,
+              "default": "composeWithTypography",
+              "description": "スタイルにベースタイポグラフィスタイルを自動追加",
+              "inheritedFrom": {
+                "name": "TypographyWebComponent",
+                "module": "packages/core/typography/typography-web-component.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "currentStep",
+              "type": {
+                "text": "string | null"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "currentStepChanged",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "define",
+              "static": true,
+              "return": {
+                "type": {
+                  "text": "typeof WebComponent"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "cfg",
+                  "optional": true,
+                  "type": {
+                    "text": "WebComponentConfig"
+                  }
+                }
+              ],
+              "description": "defineメソッドをオーバーライド\n自動的にタイポグラフィスタイルを追加",
+              "inheritedFrom": {
+                "name": "WebComponent",
+                "module": "packages/core/web-components.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "definition",
+              "readonly": true,
+              "type": {
+                "text": "object"
+              },
+              "static": true,
+              "default": "{ name: 'dads-progress', template: html` <div part=\"root\" id=\"root\"> <div part=\"label\" id=\"label\" hidden> <slot name=\"label\" id=\"label-slot\"></slot> </div> <div part=\"bar\" id=\"bar\" role=\"progressbar\"> <div part=\"track\" id=\"track\" aria-hidden=\"true\"> <span part=\"fill\" id=\"fill\"></span> </div> <svg part=\"circular-svg\" id=\"circular-svg\" viewBox=\"0 0 100 100\" aria-hidden=\"true\" focusable=\"false\"> <circle part=\"circular-track\" id=\"circular-track\" cx=\"50\" cy=\"50\" r=\"45\"></circle> <circle part=\"circular-fill\" id=\"circular-fill\" cx=\"50\" cy=\"50\" r=\"45\"></circle> </svg> <div part=\"segments\" id=\"segments\" aria-hidden=\"true\"></div> </div> <div part=\"value-text\" id=\"value-text\" hidden> <slot name=\"value-text\" id=\"value-text-slot\"></slot> <span id=\"value-text-attr\"></span> </div> <p part=\"visually-hidden status\" id=\"status\"></p> </div> `, styles: withReset([ applyDADSTokens(), progressTokens, progressStyles, ], 'minimal'), attributes: [ PropertyAttr('shape'), PropertyAttr('size'), PropertyAttr('min'), PropertyAttr('max'), PropertyAttr('value'), BooleanAttr('indeterminate'), PropertyAttr('statusLive', 'status-live'), PropertyAttr('valueText', 'value-text'), PropertyAttr('segmentMode', 'segment-mode'), PropertyAttr('segments'), PropertyAttr('currentStep', 'current-step'), PropertyAttr('totalSteps', 'total-steps'), TransferringPropertyAttr('bar', 'ariaLabel', 'aria-label'), TransferringPropertyAttr('bar', 'ariaLabelledby', 'aria-labelledby'), ], }",
+              "inheritedFrom": {
+                "name": "WebComponent",
+                "module": "packages/core/web-components.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "emitEvent",
+              "parameters": [
+                {
+                  "name": "type",
+                  "type": {
+                    "text": "string"
+                  }
+                },
+                {
+                  "name": "detail",
+                  "optional": true,
+                  "type": {
+                    "text": "T"
+                  }
+                },
+                {
+                  "name": "opts",
+                  "optional": true,
+                  "type": {
+                    "text": "CustomEventInit<T>"
+                  }
+                }
+              ],
+              "inheritedFrom": {
+                "name": "WebComponent",
+                "module": "packages/core/web-components.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "forwardEvent",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ],
+              "inheritedFrom": {
+                "name": "WebComponent",
+                "module": "packages/core/web-components.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "indeterminate",
+              "type": {
+                "text": "boolean"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "indeterminateChanged",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "field",
+              "name": "max",
+              "type": {
+                "text": "string | null"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "maxChanged",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "field",
+              "name": "min",
+              "type": {
+                "text": "string | null"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "minChanged",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "field",
+              "name": "refs",
+              "readonly": true,
+              "inheritedFrom": {
+                "name": "WebComponent",
+                "module": "packages/core/web-components.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "segmentMode",
+              "type": {
+                "text": "string | null"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "segmentModeChanged",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "field",
+              "name": "segments",
+              "type": {
+                "text": "string | null"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "segmentsChanged",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "field",
+              "name": "shape",
+              "type": {
+                "text": "string | null"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "shapeChanged",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "field",
+              "name": "size",
+              "type": {
+                "text": "string | null"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "sizeChanged",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "field",
+              "name": "statusLive",
+              "type": {
+                "text": "string | null"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "statusLiveChanged",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "field",
+              "name": "totalSteps",
+              "type": {
+                "text": "string | null"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "totalStepsChanged",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "transferDelegatedAttributes",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "inheritedFrom": {
+                "name": "WebComponent",
+                "module": "packages/core/web-components.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "value",
+              "type": {
+                "text": "string | null"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "valueChanged",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "field",
+              "name": "valueText",
+              "type": {
+                "text": "string | null"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "valueTextChanged",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "field",
+              "name": "version",
+              "type": {
+                "text": "string"
+              },
+              "static": true,
+              "readonly": true,
+              "default": "'0.1.0'"
+            }
+          ],
+          "attributes": [
+            {
+              "type": {
+                "text": "string"
+              },
+              "description": "stepsモード時の現在ステップ",
+              "name": "current-step"
+            },
+            {
+              "type": {
+                "text": "boolean"
+              },
+              "description": "不確定状態",
+              "name": "indeterminate"
+            },
+            {
+              "type": {
+                "text": "string"
+              },
+              "description": "最大値",
+              "name": "max"
+            },
+            {
+              "type": {
+                "text": "string"
+              },
+              "description": "最小値",
+              "name": "min"
+            },
+            {
+              "type": {
+                "text": "'ratio' | 'steps'"
+              },
+              "description": "segmented 用モード",
+              "name": "segment-mode"
+            },
+            {
+              "type": {
+                "text": "string"
+              },
+              "description": "ratioモード時の分割数",
+              "name": "segments"
+            },
+            {
+              "type": {
+                "text": "'linear' | 'circular' | 'segmented'"
+              },
+              "description": "表示形状",
+              "name": "shape"
+            },
+            {
+              "type": {
+                "text": "'sm' | 'md' | 'lg'"
+              },
+              "description": "サイズ",
+              "name": "size"
+            },
+            {
+              "type": {
+                "text": "'off' | 'polite' | 'assertive'"
+              },
+              "description": "live通知レベル",
+              "name": "status-live"
+            },
+            {
+              "type": {
+                "text": "string"
+              },
+              "description": "stepsモード時の総ステップ",
+              "name": "total-steps"
+            },
+            {
+              "type": {
+                "text": "string"
+              },
+              "description": "現在値",
+              "name": "value"
+            },
+            {
+              "type": {
+                "text": "string"
+              },
+              "description": "aria-valuetext / 可視値の明示上書き",
+              "name": "value-text"
+            }
+          ],
+          "superclass": {
+            "name": "TypographyWebComponent",
+            "module": "/packages/core/typography/typography-web-component.js"
+          },
+          "tagName": "dads-progress",
+          "customElement": true,
+          "events": [],
+          "modulePath": "./packages/components/progress/progress.ts",
+          "definitionPath": "./packages/components/progress/progress.ts",
+          "typeDefinitionPath": "./packages/components/progress/progress.ts",
+          "custom": {
+            "a11yAnnotations": {
+              "version": 1,
+              "summary": "線形・円形・分割表示を切り替えられる進捗表示コンポーネント",
+              "categories": {
+                "semantics": [
+                  "role=\"progressbar\" を内部 bar に設定",
+                  "determinate 時は aria-valuemin / aria-valuemax / aria-valuenow を同期",
+                  "indeterminate 時は aria-valuenow を外し aria-valuetext で状態を通知"
+                ],
+                "states": [
+                  "shape=\"linear | circular | segmented\" で表示を切替",
+                  "segment-mode=\"ratio | steps\" で segmented の算出ロジックを切替",
+                  "status-live=\"off | polite | assertive\" で live通知方針を切替"
+                ],
+                "labels": [
+                  "slot=\"label\" で可視ラベルを提供",
+                  "slot=\"value-text\" または value-text 属性で可視値テキストを提供",
+                  "aria-label / aria-labelledby は内部 progressbar へ転送"
+                ],
+                "motion": [
+                  "indeterminate 時は形状ごとのアニメーションで進行中を表現",
+                  "prefers-reduced-motion: reduce でアニメーションを停止"
+                ],
+                "contrast": [
+                  "forced-colors: active でトラック/フィルをシステム色に置換",
+                  "高コントラスト環境でも進捗差分が識別可能"
+                ]
+              },
+              "callouts": [
+                {
+                  "id": "progress-bar",
+                  "title": "進捗本体（progressbar）",
+                  "label": "part=\"bar\"",
+                  "description": "スクリーンリーダーが参照する aria-* 値を保持する中核要素です。",
+                  "category": "semantics",
+                  "target": {
+                    "scope": "shadow",
+                    "selector": "[part=\"bar\"]"
+                  },
+                  "placement": "top-left"
+                },
+                {
+                  "id": "progress-track",
+                  "title": "線形トラック",
+                  "label": "part=\"track\"",
+                  "description": "linear 形状時のトラック。fill が現在値に応じて伸縮します。",
+                  "category": "states",
+                  "target": {
+                    "scope": "shadow",
+                    "selector": "[part=\"track\"]"
+                  },
+                  "placement": "top-right"
+                },
+                {
+                  "id": "progress-fill",
+                  "title": "線形フィル",
+                  "label": "part=\"fill\"",
+                  "description": "determinate では割合に応じて幅が更新され、indeterminate では進行中アニメーションを表示します。",
+                  "category": "states",
+                  "target": {
+                    "scope": "shadow",
+                    "selector": "[part=\"fill\"]"
+                  },
+                  "placement": "bottom-right"
+                },
+                {
+                  "id": "progress-circular",
+                  "title": "円形表示",
+                  "label": "part=\"circular-svg\"",
+                  "description": "circular 形状時に stroke-dashoffset で進捗を表現します。",
+                  "category": "states",
+                  "target": {
+                    "scope": "shadow",
+                    "selector": "[part=\"circular-svg\"]"
+                  },
+                  "placement": "top-left"
+                },
+                {
+                  "id": "progress-segments",
+                  "title": "分割表示",
+                  "label": "part=\"segments\"",
+                  "description": "segmented 形状時に ratio/steps モードで塗り区画数を制御します。",
+                  "category": "states",
+                  "target": {
+                    "scope": "shadow",
+                    "selector": "[part=\"segments\"]"
+                  },
+                  "placement": "bottom-left"
+                },
+                {
+                  "id": "progress-status",
+                  "title": "ライブ通知領域",
+                  "label": "part=\"status\"",
+                  "description": "status-live が polite/assertive の場合のみ aria-live を有効化し、値変化時に通知します。",
+                  "category": "semantics",
+                  "target": {
+                    "scope": "shadow",
+                    "selector": "[part~=\"status\"]"
+                  },
+                  "placement": "bottom-right"
+                }
+              ]
+            },
+            "componentId": "progress",
+            "install": {
+              "id": "progress",
+              "define": "defineProgress",
+              "call": "prefix-registry",
+              "deps": [],
+              "source": {
+                "componentDir": "packages/components/progress"
+              },
+              "tags": [
+                "dads-progress"
+              ]
+            }
+          }
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "DadsProgress",
+          "declaration": {
+            "name": "DadsProgress",
+            "module": "packages/components/progress/progress.ts"
+          }
+        }
+      ],
+      "typeDefinitionPath": "./packages/components/progress/progress.ts"
+    },
+    {
+      "kind": "javascript-module",
+      "path": "./packages/components/progress/progress.ts",
+      "deprecated": false,
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "custom-element-definition",
+          "name": "dads-progress",
+          "declaration": {
+            "name": "DadsProgress",
+            "module": "./packages/components/progress/progress.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "./packages/components/radio/radio.ts",
       "declarations": [
         {
@@ -47330,6 +48390,14 @@
           "name": "*",
           "declaration": {
             "name": "*",
+            "module": "packages/components/progress/index.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "*",
+          "declaration": {
+            "name": "*",
             "module": "packages/components/chip-label/index.js"
           }
         },
@@ -49042,6 +50110,226 @@
           "declaration": {
             "name": "pageNavigationTokens",
             "module": "packages/components/page-navigation/page-navigation-tokens.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "packages/components/progress/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "*",
+          "declaration": {
+            "name": "*",
+            "module": "packages/components/progress/progress.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "autoDefineProgress",
+          "declaration": {
+            "name": "autoDefineProgress",
+            "module": "./progress-define.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "defineDefaultProgress",
+          "declaration": {
+            "name": "defineDefaultProgress",
+            "module": "./progress-define.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "defineProgress",
+          "declaration": {
+            "name": "defineProgress",
+            "module": "./progress-define.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "progressLocalTokens",
+          "declaration": {
+            "name": "progressLocalTokens",
+            "module": "./progress-tokens.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "progressSemanticTokens",
+          "declaration": {
+            "name": "progressSemanticTokens",
+            "module": "./progress-tokens.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "progressStyles",
+          "declaration": {
+            "name": "progressStyles",
+            "module": "./progress-styles.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "progressTokens",
+          "declaration": {
+            "name": "progressTokens",
+            "module": "./progress-tokens.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "packages/components/progress/progress-define.ts",
+      "declarations": [
+        {
+          "kind": "function",
+          "name": "autoDefineProgress",
+          "return": {
+            "type": {
+              "text": "void"
+            }
+          }
+        },
+        {
+          "kind": "function",
+          "name": "defineDefaultProgress",
+          "return": {
+            "type": {
+              "text": "void"
+            }
+          }
+        },
+        {
+          "kind": "function",
+          "name": "defineProgress",
+          "return": {
+            "type": {
+              "text": "void"
+            }
+          },
+          "parameters": [
+            {
+              "name": "prefix",
+              "optional": true,
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "name": "registry",
+              "optional": true,
+              "type": {
+                "text": "CustomElementRegistry"
+              }
+            }
+          ],
+          "description": "Progress コンポーネントを登録"
+        },
+        {
+          "kind": "variable",
+          "name": "name",
+          "default": "`${effectivePrefix}-progress`"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "autoDefineProgress",
+          "declaration": {
+            "name": "autoDefineProgress",
+            "module": "packages/components/progress/progress-define.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "defineDefaultProgress",
+          "declaration": {
+            "name": "defineDefaultProgress",
+            "module": "packages/components/progress/progress-define.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "defineProgress",
+          "declaration": {
+            "name": "defineProgress",
+            "module": "packages/components/progress/progress-define.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "packages/components/progress/progress-styles.ts",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "progressStyles",
+          "default": "css` :host { display: block; min-width: 0; font-family: var(--font-family-sans); color: var(--dads-progress-label-color); } [part=\"root\"] { display: grid; gap: var(--progress-label-gap); } [part=\"label\"] { color: var(--dads-progress-label-color); font-size: var(--font-size-14, 0.875rem); line-height: 1.5; } [part=\"value-text\"] { color: var(--dads-progress-value-color); font-size: var(--font-size-14, 0.875rem); line-height: 1.5; } [part=\"bar\"] { display: grid; place-items: center; } [part=\"track\"], [part=\"circular-svg\"], [part=\"segments\"] { display: none; } :host([shape=\"linear\"]) [part=\"track\"] { position: relative; display: block; width: 100%; min-width: 0; height: var(--dads-progress-height); border-radius: var(--dads-progress-radius); overflow: hidden; background-color: var(--dads-progress-track-color); } :host([shape=\"linear\"]) [part=\"fill\"] { display: block; width: var(--_dads-progress-ratio-percent, 0%); height: 100%; border-radius: inherit; background-color: var(--dads-progress-fill-color); transition: width var(--dads-progress-animation-duration) ease; } :host([shape=\"linear\"][indeterminate]) [part=\"fill\"] { width: 36%; animation: dads-progress-linear-indeterminate var(--dads-progress-animation-duration) ease-in-out infinite; } :host([shape=\"circular\"]) [part=\"circular-svg\"] { display: block; width: var(--dads-progress-size); height: var(--dads-progress-size); transform: rotate(-90deg); } [part=\"circular-track\"], [part=\"circular-fill\"] { fill: none; stroke-width: var(--dads-progress-stroke-width); } [part=\"circular-track\"] { stroke: var(--dads-progress-track-color); } [part=\"circular-fill\"] { stroke: var(--dads-progress-fill-color); stroke-linecap: round; transition: stroke-dashoffset var(--dads-progress-animation-duration) ease; } :host([shape=\"circular\"][indeterminate]) [part=\"circular-svg\"] { animation: dads-progress-spin calc(var(--dads-progress-animation-duration) * 1.5) linear infinite; } :host([shape=\"circular\"][indeterminate]) [part=\"circular-fill\"] { stroke-dasharray: calc(var(--_dads-progress-circumference, 282.743) * 0.35) calc(var(--_dads-progress-circumference, 282.743) * 0.65); animation: dads-progress-circular-indeterminate var(--dads-progress-animation-duration) ease-in-out infinite; } :host([shape=\"segmented\"]) [part=\"segments\"] { display: grid; width: 100%; min-width: 0; gap: var(--dads-progress-segment-gap); } [part=\"segment\"] { position: relative; display: block; height: var(--dads-progress-height); border-radius: var(--dads-progress-radius); overflow: hidden; background-color: var(--dads-progress-track-color); } [part=\"segment-fill\"] { display: block; width: 100%; height: 100%; background-color: var(--dads-progress-fill-color); transform: scaleX(0); transform-origin: left center; transition: transform var(--dads-progress-animation-duration) ease; } [part=\"segment\"][data-filled=\"true\"] [part=\"segment-fill\"] { transform: scaleX(1); } :host([shape=\"segmented\"][indeterminate]) [part=\"segment-fill\"] { transform: scaleX(1); opacity: 0.45; animation: dads-progress-segment-indeterminate var(--dads-progress-animation-duration) ease-in-out infinite; } ${visuallyHiddenPartStyles} @keyframes dads-progress-linear-indeterminate { 0% { transform: translateX(-130%); } 100% { transform: translateX(310%); } } @keyframes dads-progress-spin { from { transform: rotate(-90deg); } to { transform: rotate(270deg); } } @keyframes dads-progress-circular-indeterminate { 0% { stroke-dashoffset: calc(var(--_dads-progress-circumference, 282.743) * 0.95); } 50% { stroke-dashoffset: calc(var(--_dads-progress-circumference, 282.743) * 0.35); } 100% { stroke-dashoffset: calc(var(--_dads-progress-circumference, 282.743) * 0.95); } } @keyframes dads-progress-segment-indeterminate { 0%, 100% { opacity: 0.35; } 50% { opacity: 0.85; } } @media (forced-colors: active) { [part=\"track\"], [part=\"segment\"] { background-color: Canvas; border: 1px solid CanvasText; forced-color-adjust: none; } [part=\"fill\"], [part=\"segment-fill\"] { background-color: Highlight; forced-color-adjust: none; } [part=\"circular-track\"] { stroke: CanvasText; forced-color-adjust: none; } [part=\"circular-fill\"] { stroke: Highlight; forced-color-adjust: none; } } @media (prefers-reduced-motion: reduce) { [part=\"fill\"], [part=\"circular-fill\"], [part=\"segment-fill\"], [part=\"circular-svg\"] { transition: none; animation: none; } } `"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "progressStyles",
+          "declaration": {
+            "name": "progressStyles",
+            "module": "packages/components/progress/progress-styles.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "packages/components/progress/progress-tokens.ts",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "progressLocalTokens",
+          "default": "css`${progressLocalTokensText}`"
+        },
+        {
+          "kind": "variable",
+          "name": "progressSemanticTokens",
+          "default": "css`${progressSemanticTokensText}`"
+        },
+        {
+          "kind": "variable",
+          "name": "progressTokens",
+          "default": "css` ${progressSemanticTokensText} ${progressLocalTokensText} `"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "progressLocalTokens",
+          "declaration": {
+            "name": "progressLocalTokens",
+            "module": "packages/components/progress/progress-tokens.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "progressSemanticTokens",
+          "declaration": {
+            "name": "progressSemanticTokens",
+            "module": "packages/components/progress/progress-tokens.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "progressTokens",
+          "declaration": {
+            "name": "progressTokens",
+            "module": "packages/components/progress/progress-tokens.ts"
           }
         }
       ]

--- a/docs/knowledge/a11y-annotations.json
+++ b/docs/knowledge/a11y-annotations.json
@@ -2853,6 +2853,109 @@
       }
     ]
   },
+  "dads-progress": {
+    "version": 1,
+    "summary": "線形・円形・分割表示を切り替えられる進捗表示コンポーネント",
+    "categories": {
+      "semantics": [
+        "role=\"progressbar\" を内部 bar に設定",
+        "determinate 時は aria-valuemin / aria-valuemax / aria-valuenow を同期",
+        "indeterminate 時は aria-valuenow を外し aria-valuetext で状態を通知"
+      ],
+      "states": [
+        "shape=\"linear | circular | segmented\" で表示を切替",
+        "segment-mode=\"ratio | steps\" で segmented の算出ロジックを切替",
+        "status-live=\"off | polite | assertive\" で live通知方針を切替"
+      ],
+      "labels": [
+        "slot=\"label\" で可視ラベルを提供",
+        "slot=\"value-text\" または value-text 属性で可視値テキストを提供",
+        "aria-label / aria-labelledby は内部 progressbar へ転送"
+      ],
+      "motion": [
+        "indeterminate 時は形状ごとのアニメーションで進行中を表現",
+        "prefers-reduced-motion: reduce でアニメーションを停止"
+      ],
+      "contrast": [
+        "forced-colors: active でトラック/フィルをシステム色に置換",
+        "高コントラスト環境でも進捗差分が識別可能"
+      ]
+    },
+    "callouts": [
+      {
+        "id": "progress-bar",
+        "title": "進捗本体（progressbar）",
+        "label": "part=\"bar\"",
+        "description": "スクリーンリーダーが参照する aria-* 値を保持する中核要素です。",
+        "category": "semantics",
+        "target": {
+          "scope": "shadow",
+          "selector": "[part=\"bar\"]"
+        },
+        "placement": "top-left"
+      },
+      {
+        "id": "progress-track",
+        "title": "線形トラック",
+        "label": "part=\"track\"",
+        "description": "linear 形状時のトラック。fill が現在値に応じて伸縮します。",
+        "category": "states",
+        "target": {
+          "scope": "shadow",
+          "selector": "[part=\"track\"]"
+        },
+        "placement": "top-right"
+      },
+      {
+        "id": "progress-fill",
+        "title": "線形フィル",
+        "label": "part=\"fill\"",
+        "description": "determinate では割合に応じて幅が更新され、indeterminate では進行中アニメーションを表示します。",
+        "category": "states",
+        "target": {
+          "scope": "shadow",
+          "selector": "[part=\"fill\"]"
+        },
+        "placement": "bottom-right"
+      },
+      {
+        "id": "progress-circular",
+        "title": "円形表示",
+        "label": "part=\"circular-svg\"",
+        "description": "circular 形状時に stroke-dashoffset で進捗を表現します。",
+        "category": "states",
+        "target": {
+          "scope": "shadow",
+          "selector": "[part=\"circular-svg\"]"
+        },
+        "placement": "top-left"
+      },
+      {
+        "id": "progress-segments",
+        "title": "分割表示",
+        "label": "part=\"segments\"",
+        "description": "segmented 形状時に ratio/steps モードで塗り区画数を制御します。",
+        "category": "states",
+        "target": {
+          "scope": "shadow",
+          "selector": "[part=\"segments\"]"
+        },
+        "placement": "bottom-left"
+      },
+      {
+        "id": "progress-status",
+        "title": "ライブ通知領域",
+        "label": "part=\"status\"",
+        "description": "status-live が polite/assertive の場合のみ aria-live を有効化し、値変化時に通知します。",
+        "category": "semantics",
+        "target": {
+          "scope": "shadow",
+          "selector": "[part~=\"status\"]"
+        },
+        "placement": "bottom-right"
+      }
+    ]
+  },
   "dads-switch": {
     "version": 1,
     "summary": "トグルスイッチ（ON/OFF切り替え）",

--- a/docs/knowledge/learnings.md
+++ b/docs/knowledge/learnings.md
@@ -4,6 +4,29 @@
 
 ---
 
+## [2026-02-11] postflight の base coverage は「比較対象ブランチのテスト健全性」に依存する
+**タグ**: #frontend-postflight #coverage #vitest #git-worktree #quality-gate
+
+### 概要
+`frontend-postflight` の base 比較で、HEAD 側は通るのに base 側だけ coverage 取得が失敗するケースが発生した。  
+今回の失敗は新規実装ではなく、base 側テスト（`packages/components/annotate/annotate.test.ts`）が `window.localStorage.setItem` を呼び出した際に `TypeError` となる既知不安定条件だった。
+
+### 学び
+1. postflight の coverage gate は「差分品質」だけでなく「base のテスト実行性」も前提条件になる。
+2. base 側が 1 件でも fail すると delta は算出不能になり、仕様通り `BLOCKER` 扱いにするのが正しい。
+3. 失敗時は「HEAD の品質ゲート（`npm run ci` など）」と「base 失敗ログ」を分離して記録すると、差分起因か基盤起因かを切り分けやすい。
+
+### 今回の観測
+- base 実行コマンド: `npm run test:coverage -- --run --coverage.reporter=json-summary --coverage.reporter=text-summary --coverage.reportsDirectory=coverage-postflight-base`
+- base 結果: `packages/components/annotate/annotate.test.ts` の `CEMロード失敗時でも無限refreshしない` が fail
+- エラー: `TypeError: window.localStorage.setItem is not a function`（`annotate.test.ts:58`）
+- HEAD 側は `npm run ci` が通過し、実装側の回帰は未検出
+
+### 再発防止
+- postflight 実行時は、coverage 比較の前提として「base 側テストが全件通るか」を先に確認する。
+- base 側 fail 時は無理に delta を推定せず、`BLOCKER` を明示して PR へ切り分けメモを残す。
+- 可能なら base worktree の配置・実行環境を固定し、テスト環境差（localStorage 等）の再現性を下げる。
+
 ## [2026-02-10] Divider余白は「内部解決したshorthand変数」を1回だけmargin適用する
 **タグ**: #divider #css-variables #webcomponents #a11y #coverage
 

--- a/packages/autoload/dads/progress.ts
+++ b/packages/autoload/dads/progress.ts
@@ -1,0 +1,9 @@
+/**
+ * wc-autoloader アダプター: dads-progress
+ * このファイルがインポートされるとコンポーネントが自動登録される
+ */
+import { DadsProgress, defineDefaultProgress } from '../../components/progress/index.js';
+
+defineDefaultProgress();
+
+export default DadsProgress;

--- a/packages/components/index.ts
+++ b/packages/components/index.ts
@@ -47,6 +47,9 @@ export * from './reset-card-demo.js';
 // スイッチ
 export * from './switch/index.js';
 
+// プログレス
+export * from './progress/index.js';
+
 // チップラベル
 export * from './chip-label/index.js';
 

--- a/packages/components/progress/index.ts
+++ b/packages/components/progress/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Progress コンポーネント モジュールエクスポート
+ */
+export * from './progress.js';
+export { defineProgress, defineDefaultProgress, autoDefineProgress } from './progress-define.js';
+export { progressTokens, progressSemanticTokens, progressLocalTokens } from './progress-tokens.js';
+export { progressStyles } from './progress-styles.js';

--- a/packages/components/progress/progress-define.ts
+++ b/packages/components/progress/progress-define.ts
@@ -1,0 +1,28 @@
+/**
+ * Progress コンポーネント登録ヘルパー
+ */
+import { WebComponentDefinition } from '../../core/web-components.js';
+import { getConfig, getPrefix } from '../../config.js';
+import { DadsProgress } from './progress.js';
+
+/**
+ * Progress コンポーネントを登録
+ */
+export function defineProgress(prefix?: string, registry?: CustomElementRegistry): void {
+  const effectivePrefix = prefix ?? getPrefix();
+  const effectiveRegistry = registry ?? getConfig().registry;
+
+  const name = `${effectivePrefix}-progress`;
+  if (effectiveRegistry.get(name)) return;
+
+  const def = { ...DadsProgress.definition, name, registry: effectiveRegistry };
+  WebComponentDefinition.compose(DadsProgress, def).define(effectiveRegistry);
+}
+
+export function defineDefaultProgress(): void {
+  defineProgress();
+}
+
+export function autoDefineProgress(): void {
+  if (typeof customElements !== 'undefined') defineDefaultProgress();
+}

--- a/packages/components/progress/progress-styles.ts
+++ b/packages/components/progress/progress-styles.ts
@@ -1,0 +1,226 @@
+/**
+ * Progress styles
+ */
+import { css } from '../../core/web-components.js';
+
+const visuallyHiddenPartStyles = `
+  [part~="visually-hidden"] {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+`;
+
+export const progressStyles = css`
+  :host {
+    display: block;
+    min-width: 0;
+    font-family: var(--font-family-sans);
+    color: var(--dads-progress-label-color);
+  }
+
+  [part="root"] {
+    display: grid;
+    gap: var(--progress-label-gap);
+  }
+
+  [part="label"] {
+    color: var(--dads-progress-label-color);
+    font-size: var(--font-size-14, 0.875rem);
+    line-height: 1.5;
+  }
+
+  [part="value-text"] {
+    color: var(--dads-progress-value-color);
+    font-size: var(--font-size-14, 0.875rem);
+    line-height: 1.5;
+  }
+
+  [part="bar"] {
+    display: grid;
+    place-items: center;
+  }
+
+  [part="track"],
+  [part="circular-svg"],
+  [part="segments"] {
+    display: none;
+  }
+
+  :host([shape="linear"]) [part="track"] {
+    position: relative;
+    display: block;
+    width: 100%;
+    min-width: 0;
+    height: var(--dads-progress-height);
+    border-radius: var(--dads-progress-radius);
+    overflow: hidden;
+    background-color: var(--dads-progress-track-color);
+  }
+
+  :host([shape="linear"]) [part="fill"] {
+    display: block;
+    width: var(--_dads-progress-ratio-percent, 0%);
+    height: 100%;
+    border-radius: inherit;
+    background-color: var(--dads-progress-fill-color);
+    transition: width var(--dads-progress-animation-duration) ease;
+  }
+
+  :host([shape="linear"][indeterminate]) [part="fill"] {
+    width: 36%;
+    animation: dads-progress-linear-indeterminate var(--dads-progress-animation-duration) ease-in-out infinite;
+  }
+
+  :host([shape="circular"]) [part="circular-svg"] {
+    display: block;
+    width: var(--dads-progress-size);
+    height: var(--dads-progress-size);
+    transform: rotate(-90deg);
+  }
+
+  [part="circular-track"],
+  [part="circular-fill"] {
+    fill: none;
+    stroke-width: var(--dads-progress-stroke-width);
+  }
+
+  [part="circular-track"] {
+    stroke: var(--dads-progress-track-color);
+  }
+
+  [part="circular-fill"] {
+    stroke: var(--dads-progress-fill-color);
+    stroke-linecap: round;
+    transition: stroke-dashoffset var(--dads-progress-animation-duration) ease;
+  }
+
+  :host([shape="circular"][indeterminate]) [part="circular-svg"] {
+    animation: dads-progress-spin calc(var(--dads-progress-animation-duration) * 1.5) linear infinite;
+  }
+
+  :host([shape="circular"][indeterminate]) [part="circular-fill"] {
+    stroke-dasharray: calc(var(--_dads-progress-circumference, 282.743) * 0.35)
+      calc(var(--_dads-progress-circumference, 282.743) * 0.65);
+    animation: dads-progress-circular-indeterminate var(--dads-progress-animation-duration) ease-in-out infinite;
+  }
+
+  :host([shape="segmented"]) [part="segments"] {
+    display: grid;
+    width: 100%;
+    min-width: 0;
+    gap: var(--dads-progress-segment-gap);
+  }
+
+  [part="segment"] {
+    position: relative;
+    display: block;
+    height: var(--dads-progress-height);
+    border-radius: var(--dads-progress-radius);
+    overflow: hidden;
+    background-color: var(--dads-progress-track-color);
+  }
+
+  [part="segment-fill"] {
+    display: block;
+    width: 100%;
+    height: 100%;
+    background-color: var(--dads-progress-fill-color);
+    transform: scaleX(0);
+    transform-origin: left center;
+    transition: transform var(--dads-progress-animation-duration) ease;
+  }
+
+  [part="segment"][data-filled="true"] [part="segment-fill"] {
+    transform: scaleX(1);
+  }
+
+  :host([shape="segmented"][indeterminate]) [part="segment-fill"] {
+    transform: scaleX(1);
+    opacity: 0.45;
+    animation: dads-progress-segment-indeterminate var(--dads-progress-animation-duration) ease-in-out infinite;
+  }
+
+  ${visuallyHiddenPartStyles}
+
+  @keyframes dads-progress-linear-indeterminate {
+    0% {
+      transform: translateX(-130%);
+    }
+    100% {
+      transform: translateX(310%);
+    }
+  }
+
+  @keyframes dads-progress-spin {
+    from {
+      transform: rotate(-90deg);
+    }
+    to {
+      transform: rotate(270deg);
+    }
+  }
+
+  @keyframes dads-progress-circular-indeterminate {
+    0% {
+      stroke-dashoffset: calc(var(--_dads-progress-circumference, 282.743) * 0.95);
+    }
+    50% {
+      stroke-dashoffset: calc(var(--_dads-progress-circumference, 282.743) * 0.35);
+    }
+    100% {
+      stroke-dashoffset: calc(var(--_dads-progress-circumference, 282.743) * 0.95);
+    }
+  }
+
+  @keyframes dads-progress-segment-indeterminate {
+    0%,
+    100% {
+      opacity: 0.35;
+    }
+    50% {
+      opacity: 0.85;
+    }
+  }
+
+  @media (forced-colors: active) {
+    [part="track"],
+    [part="segment"] {
+      background-color: Canvas;
+      border: 1px solid CanvasText;
+      forced-color-adjust: none;
+    }
+
+    [part="fill"],
+    [part="segment-fill"] {
+      background-color: Highlight;
+      forced-color-adjust: none;
+    }
+
+    [part="circular-track"] {
+      stroke: CanvasText;
+      forced-color-adjust: none;
+    }
+
+    [part="circular-fill"] {
+      stroke: Highlight;
+      forced-color-adjust: none;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    [part="fill"],
+    [part="circular-fill"],
+    [part="segment-fill"],
+    [part="circular-svg"] {
+      transition: none;
+      animation: none;
+    }
+  }
+`;

--- a/packages/components/progress/progress-tokens.ts
+++ b/packages/components/progress/progress-tokens.ts
@@ -1,0 +1,68 @@
+/**
+ * Progress tokens (semantic + local override API)
+ */
+import { css } from '../../core/web-components.js';
+
+const progressSemanticTokensText = `
+  :host {
+    /* ========== Color ========== */
+    --progress-track-color: var(--color-neutral-solid-gray-100, #e6e6e6);
+    --progress-fill-color: var(--color-primary, #00118f);
+    --progress-label-color: var(--color-neutral-solid-gray-800, #333333);
+    --progress-value-color: var(--color-neutral-solid-gray-700, #4d4d4d);
+
+    /* ========== Layout ========== */
+    --progress-height-sm: calc(6 / 16 * 1rem);
+    --progress-height-md: calc(10 / 16 * 1rem);
+    --progress-height-lg: calc(14 / 16 * 1rem);
+    --progress-radius: var(--border-radius-full, 9999px);
+
+    --progress-circular-size-sm: calc(40 / 16 * 1rem);
+    --progress-circular-size-md: calc(56 / 16 * 1rem);
+    --progress-circular-size-lg: calc(72 / 16 * 1rem);
+    --progress-circular-stroke-width-sm: calc(4 / 16 * 1rem);
+    --progress-circular-stroke-width-md: calc(6 / 16 * 1rem);
+    --progress-circular-stroke-width-lg: calc(8 / 16 * 1rem);
+
+    --progress-segment-gap: calc(4 / 16 * 1rem);
+    --progress-label-gap: calc(8 / 16 * 1rem);
+
+    /* ========== Motion ========== */
+    --progress-animation-duration: 1.2s;
+  }
+`;
+
+const progressLocalTokensText = `
+  :host {
+    --dads-progress-track-color: var(--progress-track-color);
+    --dads-progress-fill-color: var(--progress-fill-color);
+    --dads-progress-height: var(--progress-height-md);
+    --dads-progress-radius: var(--progress-radius);
+    --dads-progress-size: var(--progress-circular-size-md);
+    --dads-progress-stroke-width: var(--progress-circular-stroke-width-md);
+    --dads-progress-segment-gap: var(--progress-segment-gap);
+    --dads-progress-animation-duration: var(--progress-animation-duration);
+    --dads-progress-label-color: var(--progress-label-color);
+    --dads-progress-value-color: var(--progress-value-color);
+  }
+
+  :host([size="sm"]) {
+    --dads-progress-height: var(--progress-height-sm);
+    --dads-progress-size: var(--progress-circular-size-sm);
+    --dads-progress-stroke-width: var(--progress-circular-stroke-width-sm);
+  }
+
+  :host([size="lg"]) {
+    --dads-progress-height: var(--progress-height-lg);
+    --dads-progress-size: var(--progress-circular-size-lg);
+    --dads-progress-stroke-width: var(--progress-circular-stroke-width-lg);
+  }
+`;
+
+export const progressSemanticTokens = css`${progressSemanticTokensText}`;
+export const progressLocalTokens = css`${progressLocalTokensText}`;
+
+export const progressTokens = css`
+  ${progressSemanticTokensText}
+  ${progressLocalTokensText}
+`;

--- a/packages/components/progress/progress.test.ts
+++ b/packages/components/progress/progress.test.ts
@@ -1,0 +1,297 @@
+/**
+ * DadsProgress コンポーネント テスト
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  cleanupTestElement,
+  createTestElement,
+  getDefinitionStyles,
+  getShadowContent,
+  renderWebComponent,
+  waitForCustomElement,
+} from '../../../tests/setup';
+
+function waitTick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function toCssText(style: string | CSSStyleSheet): string {
+  if (typeof style === 'string') return style;
+  return Array.from(style.cssRules)
+    .map((rule) => rule.cssText)
+    .join('\n');
+}
+
+describe('DadsProgress - 基本', () => {
+  let element: HTMLElement | null = null;
+
+  afterEach(() => {
+    if (element) cleanupTestElement(element);
+    element = null;
+  });
+
+  it('定義関数を重複実行しても問題なく登録される', async () => {
+    const { defineProgress } = await import('./progress-define');
+
+    defineProgress();
+    defineProgress();
+
+    expect(customElements.get('dads-progress')).toBeTruthy();
+  });
+
+  it('デフォルト属性が補完され、progressbar が設定される', async () => {
+    const { defineDefaultProgress } = await import('./progress-define');
+    defineDefaultProgress();
+
+    element = createTestElement('dads-progress');
+    await waitForCustomElement(element);
+
+    expect(element.getAttribute('shape')).toBe('linear');
+    expect(element.getAttribute('size')).toBe('md');
+    expect(element.getAttribute('min')).toBe('0');
+    expect(element.getAttribute('max')).toBe('100');
+    expect(element.getAttribute('value')).toBe('0');
+    expect(element.getAttribute('status-live')).toBe('off');
+    expect(element.getAttribute('segment-mode')).toBe('ratio');
+    expect(element.getAttribute('segments')).toBe('10');
+    expect(element.getAttribute('current-step')).toBe('0');
+    expect(element.getAttribute('total-steps')).toBe('1');
+
+    const bar = getShadowContent(element, '#bar');
+    expect(bar?.getAttribute('role')).toBe('progressbar');
+  });
+
+  it('determinate では aria-valuemin/max/now が整合し、aria-valuetext は自動生成される', async () => {
+    const { defineDefaultProgress } = await import('./progress-define');
+    defineDefaultProgress();
+
+    element = renderWebComponent('<dads-progress min="20" max="220" value="120"></dads-progress>');
+    await waitForCustomElement(element);
+
+    const bar = getShadowContent(element, '#bar');
+    expect(bar?.getAttribute('aria-valuemin')).toBe('20');
+    expect(bar?.getAttribute('aria-valuemax')).toBe('220');
+    expect(bar?.getAttribute('aria-valuenow')).toBe('120');
+    expect(bar?.getAttribute('aria-valuetext')).toBe('50%');
+  });
+
+  it('indeterminate では aria-valuenow を外し、aria-valuetext を進行中にする', async () => {
+    const { defineDefaultProgress } = await import('./progress-define');
+    defineDefaultProgress();
+
+    element = renderWebComponent('<dads-progress indeterminate></dads-progress>');
+    await waitForCustomElement(element);
+
+    const bar = getShadowContent(element, '#bar');
+    expect(bar?.hasAttribute('aria-valuenow')).toBe(false);
+    expect(bar?.getAttribute('aria-valuetext')).toBe('進行中');
+  });
+
+  it('value-text 属性を指定した場合は indeterminate 時の aria-valuetext を上書きする', async () => {
+    const { defineDefaultProgress } = await import('./progress-define');
+    defineDefaultProgress();
+
+    element = renderWebComponent('<dads-progress indeterminate value-text="読み込み中"></dads-progress>');
+    await waitForCustomElement(element);
+
+    const bar = getShadowContent(element, '#bar');
+    expect(bar?.getAttribute('aria-valuetext')).toBe('読み込み中');
+  });
+
+  it('aria-label / aria-labelledby が内部 progressbar へ転送される', async () => {
+    const { defineDefaultProgress } = await import('./progress-define');
+    defineDefaultProgress();
+
+    const wrapper = renderWebComponent(`
+      <div>
+        <span id="progress-label">進捗</span>
+        <dads-progress aria-label="ロード進捗" aria-labelledby="progress-label"></dads-progress>
+      </div>
+    `);
+
+    const component = wrapper.querySelector('dads-progress') as HTMLElement;
+    await waitForCustomElement(component);
+
+    const bar = getShadowContent(component, '#bar');
+    expect(bar?.getAttribute('aria-label')).toBe('ロード進捗');
+    expect(bar?.getAttribute('aria-labelledby')).toBe('progress-label');
+  });
+
+  it('status-live=off/polite/assertive を切り替えられる', async () => {
+    const { defineDefaultProgress } = await import('./progress-define');
+    defineDefaultProgress();
+
+    element = renderWebComponent('<dads-progress status-live="off"></dads-progress>');
+    await waitForCustomElement(element);
+
+    const status = getShadowContent(element, '#status');
+    expect(status?.hasAttribute('aria-live')).toBe(false);
+
+    element.setAttribute('status-live', 'polite');
+    await waitTick();
+    expect(status?.getAttribute('aria-live')).toBe('polite');
+    expect(status?.getAttribute('aria-atomic')).toBe('true');
+
+    element.setAttribute('status-live', 'assertive');
+    await waitTick();
+    expect(status?.getAttribute('aria-live')).toBe('assertive');
+  });
+
+  it('status-live 有効時は整数%が変わるときだけ status が更新される', async () => {
+    const { defineDefaultProgress } = await import('./progress-define');
+    defineDefaultProgress();
+
+    element = renderWebComponent('<dads-progress status-live="polite" min="0" max="100" value="10"></dads-progress>');
+    await waitForCustomElement(element);
+
+    const status = getShadowContent(element, '#status');
+    element.setAttribute('value', '10.4');
+    await waitTick();
+    expect(status?.textContent).toBe('10%');
+
+    element.setAttribute('value', '11');
+    await waitTick();
+    expect(status?.textContent).toBe('11%');
+  });
+
+  it('value-text は slot 優先で可視表示される', async () => {
+    const { defineDefaultProgress } = await import('./progress-define');
+    defineDefaultProgress();
+
+    element = renderWebComponent(`
+      <dads-progress value-text="属性テキスト">
+        <span slot="value-text">スロットテキスト</span>
+      </dads-progress>
+    `);
+    await waitForCustomElement(element);
+
+    const valueText = getShadowContent(element, '#value-text');
+    const attrFallback = getShadowContent(element, '#value-text-attr');
+
+    expect(valueText?.hasAttribute('hidden')).toBe(false);
+    expect(attrFallback?.hasAttribute('hidden')).toBe(true);
+  });
+});
+
+describe('DadsProgress - 描画', () => {
+  let element: HTMLElement | null = null;
+
+  afterEach(() => {
+    if (element) cleanupTestElement(element);
+    element = null;
+  });
+
+  it('shape=linear で fill 幅が更新される', async () => {
+    const { defineDefaultProgress } = await import('./progress-define');
+    defineDefaultProgress();
+
+    element = renderWebComponent('<dads-progress shape="linear" min="0" max="200" value="50"></dads-progress>');
+    await waitForCustomElement(element);
+
+    const fill = getShadowContent(element, '#fill') as HTMLElement | null;
+    expect(fill?.style.width).toBe('25.000%');
+  });
+
+  it('shape=circular で stroke-dashoffset が更新される', async () => {
+    const { defineDefaultProgress } = await import('./progress-define');
+    defineDefaultProgress();
+
+    element = renderWebComponent('<dads-progress shape="circular" min="0" max="100" value="75"></dads-progress>');
+    await waitForCustomElement(element);
+
+    const circle = getShadowContent(element, '#circular-fill') as SVGCircleElement | null;
+    expect(circle?.style.strokeDashoffset).not.toBe('');
+    expect(Number.parseFloat(circle?.style.strokeDashoffset ?? '')).toBeGreaterThan(0);
+  });
+
+  it('shape=segmented + segment-mode=ratio で分割数と塗り数が更新される', async () => {
+    const { defineDefaultProgress } = await import('./progress-define');
+    defineDefaultProgress();
+
+    element = renderWebComponent(
+      '<dads-progress shape="segmented" segment-mode="ratio" segments="8" min="0" max="100" value="50"></dads-progress>',
+    );
+    await waitForCustomElement(element);
+
+    const segmentEls = element.shadowRoot?.querySelectorAll('[part="segment"]') ?? [];
+    const filledEls = element.shadowRoot?.querySelectorAll('[part="segment"][data-filled="true"]') ?? [];
+
+    expect(segmentEls.length).toBe(8);
+    expect(filledEls.length).toBe(4);
+  });
+
+  it('shape=segmented + segment-mode=steps で current-step/total-steps が反映される', async () => {
+    const { defineDefaultProgress } = await import('./progress-define');
+    defineDefaultProgress();
+
+    element = renderWebComponent(
+      '<dads-progress shape="segmented" segment-mode="steps" current-step="3" total-steps="7"></dads-progress>',
+    );
+    await waitForCustomElement(element);
+
+    const segmentEls = element.shadowRoot?.querySelectorAll('[part="segment"]') ?? [];
+    const filledEls = element.shadowRoot?.querySelectorAll('[part="segment"][data-filled="true"]') ?? [];
+    const bar = getShadowContent(element, '#bar');
+
+    expect(segmentEls.length).toBe(7);
+    expect(filledEls.length).toBe(3);
+    expect(bar?.getAttribute('aria-valuemin')).toBe('0');
+    expect(bar?.getAttribute('aria-valuemax')).toBe('7');
+    expect(bar?.getAttribute('aria-valuenow')).toBe('3');
+  });
+});
+
+describe('DadsProgress - 正規化', () => {
+  let element: HTMLElement | null = null;
+
+  afterEach(() => {
+    if (element) cleanupTestElement(element);
+    element = null;
+  });
+
+  it('max <= min の場合は max = min + 1 に補正される', async () => {
+    const { defineDefaultProgress } = await import('./progress-define');
+    defineDefaultProgress();
+
+    element = renderWebComponent('<dads-progress min="10" max="10" value="99"></dads-progress>');
+    await waitForCustomElement(element);
+    await waitTick();
+
+    expect(element.getAttribute('max')).toBe('11');
+    expect(element.getAttribute('value')).toBe('11');
+  });
+
+  it('segments / total-steps / current-step が範囲内に補正される', async () => {
+    const { defineDefaultProgress } = await import('./progress-define');
+    defineDefaultProgress();
+
+    element = renderWebComponent(
+      '<dads-progress shape="segmented" segment-mode="steps" segments="999" total-steps="0" current-step="99"></dads-progress>',
+    );
+    await waitForCustomElement(element);
+    await waitTick();
+
+    expect(element.getAttribute('segments')).toBe('100');
+    expect(element.getAttribute('total-steps')).toBe('1');
+    expect(element.getAttribute('current-step')).toBe('1');
+  });
+});
+
+describe('DadsProgress - styles', () => {
+  it('主要CSS変数と forced-colors / reduced-motion ルールが定義されている', async () => {
+    const { DadsProgress } = await import('./progress');
+
+    const cssText = getDefinitionStyles(DadsProgress.definition)
+      .map((style) => toCssText(style))
+      .join('\n');
+
+    expect(cssText).toContain('--dads-progress-track-color');
+    expect(cssText).toContain('--dads-progress-fill-color');
+    expect(cssText).toContain('--dads-progress-height');
+    expect(cssText).toContain('--dads-progress-size');
+    expect(cssText).toContain('--dads-progress-segment-gap');
+    expect(cssText).toContain('@media (forced-colors: active)');
+    expect(cssText).toContain('@media (prefers-reduced-motion: reduce)');
+  });
+});

--- a/packages/components/progress/progress.ts
+++ b/packages/components/progress/progress.ts
@@ -1,0 +1,569 @@
+/**
+ * @module progress
+ * デジタル庁デザインシステム準拠 Progress コンポーネント
+ * @version 0.1.0
+ */
+
+import {
+  html,
+  BooleanAttr,
+  PropertyAttr,
+  TransferringPropertyAttr,
+} from '../../core/web-components.js';
+import { TypographyWebComponent } from '../../core/typography/typography-web-component.js';
+import { applyDADSTokens } from '../../styles/design-tokens/index.js';
+import { withReset } from '../../styles/reset-css.js';
+import { setDefaultAttributes } from '../../utils/form-component-helpers.js';
+import { hasSlotContent } from '../../utils/dom.js';
+import { progressTokens } from './progress-tokens.js';
+import { progressStyles } from './progress-styles.js';
+
+type ProgressShape = 'linear' | 'circular' | 'segmented';
+type ProgressSize = 'sm' | 'md' | 'lg';
+type StatusLive = 'off' | 'polite' | 'assertive';
+type SegmentMode = 'ratio' | 'steps';
+
+type RefsHost = { refs?: Record<string, unknown> };
+
+const CIRCULAR_RADIUS = 45;
+const CIRCULAR_CIRCUMFERENCE = 2 * Math.PI * CIRCULAR_RADIUS;
+
+function getRef<T extends Element>(host: RefsHost, id: string): T | null {
+  const el = host.refs?.[id];
+  return el instanceof Element ? (el as T) : null;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function clampInt(value: number, min: number, max: number): number {
+  return Math.trunc(clamp(value, min, max));
+}
+
+function parseNumber(value: string | null, fallback: number): number {
+  if (value == null || value.trim() === '') return fallback;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function parseIntNumber(value: string | null, fallback: number): number {
+  if (value == null || value.trim() === '') return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function normalizeShape(value: string | null): ProgressShape {
+  if (value === 'circular' || value === 'segmented') return value;
+  return 'linear';
+}
+
+function normalizeSize(value: string | null): ProgressSize {
+  if (value === 'sm' || value === 'lg') return value;
+  return 'md';
+}
+
+function normalizeStatusLive(value: string | null): StatusLive {
+  if (value === 'polite' || value === 'assertive') return value;
+  return 'off';
+}
+
+function normalizeSegmentMode(value: string | null): SegmentMode {
+  return value === 'steps' ? 'steps' : 'ratio';
+}
+
+function normalizeOptionalText(value: string | null): string | null {
+  if (value == null) return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function toPercentText(ratio: number): string {
+  return `${Math.round(clamp(ratio, 0, 1) * 100)}%`;
+}
+
+interface ProgressState {
+  shape: ProgressShape;
+  size: ProgressSize;
+  min: number;
+  max: number;
+  value: number;
+  indeterminate: boolean;
+  statusLive: StatusLive;
+  explicitValueText: string | null;
+  segmentMode: SegmentMode;
+  segments: number;
+  currentStep: number;
+  totalSteps: number;
+  ratio: number;
+  ariaMin: number;
+  ariaMax: number;
+  ariaNow: number | null;
+  ariaValueText: string;
+  segmentCount: number;
+  filledSegments: number;
+  statusKey: string;
+}
+
+/**
+ * Progress コンポーネント
+ *
+ * @customElement dads-progress
+ * @tagname dads-progress
+ *
+ * @slot label - 可視ラベル
+ * @slot value-text - 可視値テキスト
+ *
+ * @csspart root - ルート
+ * @csspart label - ラベル領域
+ * @csspart bar - 進捗本体（progressbar）
+ * @csspart track - linear のトラック
+ * @csspart fill - linear のフィル
+ * @csspart circular-svg - circular SVG
+ * @csspart circular-track - circular トラック
+ * @csspart circular-fill - circular フィル
+ * @csspart segments - segmented ラッパー
+ * @csspart segment - segmented の1区画
+ * @csspart segment-fill - segmented の塗り
+ * @csspart value-text - 可視値テキスト領域
+ * @csspart status - live領域（visually-hidden）
+ *
+ * @attr {'linear' | 'circular' | 'segmented'} shape - 表示形状
+ * @attr {'sm' | 'md' | 'lg'} size - サイズ
+ * @attr {string} min - 最小値
+ * @attr {string} max - 最大値
+ * @attr {string} value - 現在値
+ * @attr {boolean} indeterminate - 不確定状態
+ * @attr {'off' | 'polite' | 'assertive'} status-live - live通知レベル
+ * @attr {string} value-text - aria-valuetext / 可視値の明示上書き
+ * @attr {'ratio' | 'steps'} segment-mode - segmented 用モード
+ * @attr {string} segments - ratioモード時の分割数
+ * @attr {string} current-step - stepsモード時の現在ステップ
+ * @attr {string} total-steps - stepsモード時の総ステップ
+ *
+ * @cssprop --dads-progress-track-color - トラック色
+ * @cssprop --dads-progress-fill-color - フィル色
+ * @cssprop --dads-progress-height - linear/segmented 高さ
+ * @cssprop --dads-progress-radius - 角丸
+ * @cssprop --dads-progress-size - circular 直径
+ * @cssprop --dads-progress-stroke-width - circular 線幅
+ * @cssprop --dads-progress-segment-gap - segmented の間隔
+ * @cssprop --dads-progress-animation-duration - アニメーション時間
+ * @cssprop --dads-progress-label-color - ラベル色
+ * @cssprop --dads-progress-value-color - 値色
+ */
+export class DadsProgress extends TypographyWebComponent {
+  static readonly version = '0.1.0';
+
+  static definition = {
+    name: 'dads-progress',
+    template: html`
+      <div part="root" id="root">
+        <div part="label" id="label" hidden>
+          <slot name="label" id="label-slot"></slot>
+        </div>
+
+        <div part="bar" id="bar" role="progressbar">
+          <div part="track" id="track" aria-hidden="true">
+            <span part="fill" id="fill"></span>
+          </div>
+
+          <svg part="circular-svg" id="circular-svg" viewBox="0 0 100 100" aria-hidden="true" focusable="false">
+            <circle part="circular-track" id="circular-track" cx="50" cy="50" r="45"></circle>
+            <circle part="circular-fill" id="circular-fill" cx="50" cy="50" r="45"></circle>
+          </svg>
+
+          <div part="segments" id="segments" aria-hidden="true"></div>
+        </div>
+
+        <div part="value-text" id="value-text" hidden>
+          <slot name="value-text" id="value-text-slot"></slot>
+          <span id="value-text-attr"></span>
+        </div>
+
+        <p part="visually-hidden status" id="status"></p>
+      </div>
+    `,
+    styles: withReset([
+      applyDADSTokens(),
+      progressTokens,
+      progressStyles,
+    ], 'minimal'),
+    attributes: [
+      PropertyAttr('shape'),
+      PropertyAttr('size'),
+      PropertyAttr('min'),
+      PropertyAttr('max'),
+      PropertyAttr('value'),
+      BooleanAttr('indeterminate'),
+      PropertyAttr('statusLive', 'status-live'),
+      PropertyAttr('valueText', 'value-text'),
+      PropertyAttr('segmentMode', 'segment-mode'),
+      PropertyAttr('segments'),
+      PropertyAttr('currentStep', 'current-step'),
+      PropertyAttr('totalSteps', 'total-steps'),
+      TransferringPropertyAttr('bar', 'ariaLabel', 'aria-label'),
+      TransferringPropertyAttr('bar', 'ariaLabelledby', 'aria-labelledby'),
+    ],
+  };
+
+  declare shape: string | null;
+  declare size: string | null;
+  declare min: string | null;
+  declare max: string | null;
+  declare value: string | null;
+  declare indeterminate: boolean;
+  declare statusLive: string | null;
+  declare valueText: string | null;
+  declare segmentMode: string | null;
+  declare segments: string | null;
+  declare currentStep: string | null;
+  declare totalSteps: string | null;
+
+  #labelSlot: HTMLSlotElement | null = null;
+  #valueTextSlot: HTMLSlotElement | null = null;
+  #lastStatusKey: string | null = null;
+  #lastStatusMessage: string | null = null;
+  #ready = false;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+
+    setDefaultAttributes(this, {
+      shape: 'linear',
+      size: 'md',
+      min: '0',
+      max: '100',
+      value: '0',
+      'status-live': 'off',
+      'segment-mode': 'ratio',
+      segments: '10',
+      'current-step': '0',
+      'total-steps': '1',
+    });
+
+    this.#labelSlot = getRef<HTMLSlotElement>(this, 'label-slot');
+    this.#valueTextSlot = getRef<HTMLSlotElement>(this, 'value-text-slot');
+
+    this.#labelSlot?.addEventListener('slotchange', this.#handleSlotChange);
+    this.#valueTextSlot?.addEventListener('slotchange', this.#handleSlotChange);
+
+    this.#ready = true;
+    this.#render();
+  }
+
+  disconnectedCallback(): void {
+    this.#labelSlot?.removeEventListener('slotchange', this.#handleSlotChange);
+    this.#valueTextSlot?.removeEventListener('slotchange', this.#handleSlotChange);
+    this.#labelSlot = null;
+    this.#valueTextSlot = null;
+    this.#ready = false;
+    super.disconnectedCallback();
+  }
+
+  shapeChanged(): void {
+    this.#requestRender();
+  }
+
+  sizeChanged(): void {
+    this.#requestRender();
+  }
+
+  minChanged(): void {
+    this.#requestRender();
+  }
+
+  maxChanged(): void {
+    this.#requestRender();
+  }
+
+  valueChanged(): void {
+    this.#requestRender();
+  }
+
+  indeterminateChanged(): void {
+    this.#requestRender();
+  }
+
+  statusLiveChanged(): void {
+    this.#requestRender();
+  }
+
+  valueTextChanged(): void {
+    this.#requestRender();
+  }
+
+  segmentModeChanged(): void {
+    this.#requestRender();
+  }
+
+  segmentsChanged(): void {
+    this.#requestRender();
+  }
+
+  currentStepChanged(): void {
+    this.#requestRender();
+  }
+
+  totalStepsChanged(): void {
+    this.#requestRender();
+  }
+
+  #handleSlotChange = (): void => {
+    this.#syncLabelVisibility();
+    this.#syncVisibleValueText();
+  };
+
+  #requestRender(): void {
+    if (!this.#ready) return;
+    this.#render();
+  }
+
+  #render(): void {
+    const state = this.#resolveState();
+
+    this.#reflectNormalizedAttributes(state);
+    this.#syncLabelVisibility();
+    this.#syncVisibleValueText();
+    this.#syncAria(state);
+    this.#syncLinear(state);
+    this.#syncCircular(state);
+    this.#syncSegments(state);
+    this.#syncStatus(state);
+  }
+
+  #resolveState(): ProgressState {
+    const shape = normalizeShape(this.getAttribute('shape'));
+    const size = normalizeSize(this.getAttribute('size'));
+
+    const min = parseNumber(this.getAttribute('min'), 0);
+    const maxRaw = parseNumber(this.getAttribute('max'), 100);
+    const max = maxRaw <= min ? min + 1 : maxRaw;
+    const value = clamp(parseNumber(this.getAttribute('value'), 0), min, max);
+
+    const indeterminate = this.hasAttribute('indeterminate');
+    const statusLive = normalizeStatusLive(this.getAttribute('status-live'));
+    const explicitValueText = normalizeOptionalText(this.getAttribute('value-text'));
+
+    const segmentMode = normalizeSegmentMode(this.getAttribute('segment-mode'));
+    const segments = clampInt(parseIntNumber(this.getAttribute('segments'), 10), 2, 100);
+    const totalSteps = clampInt(parseIntNumber(this.getAttribute('total-steps'), 1), 1, 100);
+    const currentStep = clampInt(parseIntNumber(this.getAttribute('current-step'), 0), 0, totalSteps);
+
+    let ariaMin = min;
+    let ariaMax = max;
+    let ariaNow: number | null = value;
+    let ratio = clamp((value - min) / (max - min), 0, 1);
+
+    if (shape === 'segmented' && segmentMode === 'steps') {
+      ariaMin = 0;
+      ariaMax = totalSteps;
+      ariaNow = currentStep;
+      ratio = clamp(currentStep / totalSteps, 0, 1);
+    }
+
+    if (indeterminate) ariaNow = null;
+
+    const ariaValueText = explicitValueText ?? (indeterminate ? '進行中' : toPercentText(ratio));
+
+    let segmentCount = segments;
+    let filledSegments = Math.round(ratio * segments);
+
+    if (shape === 'segmented' && segmentMode === 'steps') {
+      segmentCount = totalSteps;
+      filledSegments = currentStep;
+    }
+
+    filledSegments = clampInt(filledSegments, 0, segmentCount);
+
+    const statusKey = indeterminate ? `indeterminate:${ariaValueText}` : `determinate:${toPercentText(ratio)}`;
+
+    return {
+      shape,
+      size,
+      min,
+      max,
+      value,
+      indeterminate,
+      statusLive,
+      explicitValueText,
+      segmentMode,
+      segments,
+      currentStep,
+      totalSteps,
+      ratio,
+      ariaMin,
+      ariaMax,
+      ariaNow,
+      ariaValueText,
+      segmentCount,
+      filledSegments,
+      statusKey,
+    };
+  }
+
+  #reflectNormalizedAttributes(state: ProgressState): void {
+    this.#setIfDifferent('shape', state.shape);
+    this.#setIfDifferent('size', state.size);
+    this.#setIfDifferent('min', String(state.min));
+    this.#setIfDifferent('max', String(state.max));
+    this.#setIfDifferent('value', String(state.value));
+    this.#setIfDifferent('status-live', state.statusLive);
+    this.#setIfDifferent('segment-mode', state.segmentMode);
+    this.#setIfDifferent('segments', String(state.segments));
+    this.#setIfDifferent('current-step', String(state.currentStep));
+    this.#setIfDifferent('total-steps', String(state.totalSteps));
+
+    const rawValueText = this.getAttribute('value-text');
+    if (state.explicitValueText == null && rawValueText != null && rawValueText.trim() === '') {
+      this.removeAttribute('value-text');
+      return;
+    }
+
+    if (state.explicitValueText != null) {
+      this.#setIfDifferent('value-text', state.explicitValueText);
+    }
+  }
+
+  #setIfDifferent(name: string, next: string): void {
+    if (this.getAttribute(name) === next) return;
+    this.setAttribute(name, next);
+  }
+
+  #syncLabelVisibility(): void {
+    const label = getRef<HTMLElement>(this, 'label');
+    if (!label) return;
+
+    const hasLabel = hasSlotContent(this.#labelSlot) || this.querySelector('[slot="label"]') !== null;
+    label.toggleAttribute('hidden', !hasLabel);
+  }
+
+  #syncVisibleValueText(): void {
+    const valueText = getRef<HTMLElement>(this, 'value-text');
+    const valueTextAttr = getRef<HTMLElement>(this, 'value-text-attr');
+    if (!valueText || !valueTextAttr) return;
+
+    const hasSlot = hasSlotContent(this.#valueTextSlot) || this.querySelector('[slot="value-text"]') !== null;
+    const attrText = normalizeOptionalText(this.getAttribute('value-text'));
+
+    valueTextAttr.textContent = hasSlot ? '' : attrText ?? '';
+    valueTextAttr.toggleAttribute('hidden', hasSlot || attrText == null);
+
+    const visible = hasSlot || attrText != null;
+    valueText.toggleAttribute('hidden', !visible);
+  }
+
+  #syncAria(state: ProgressState): void {
+    const bar = getRef<HTMLElement>(this, 'bar');
+    if (!bar) return;
+
+    bar.setAttribute('role', 'progressbar');
+    bar.setAttribute('aria-valuemin', String(state.ariaMin));
+    bar.setAttribute('aria-valuemax', String(state.ariaMax));
+
+    if (state.ariaNow == null) bar.removeAttribute('aria-valuenow');
+    else bar.setAttribute('aria-valuenow', String(state.ariaNow));
+
+    bar.setAttribute('aria-valuetext', state.ariaValueText);
+  }
+
+  #syncLinear(state: ProgressState): void {
+    const fill = getRef<HTMLElement>(this, 'fill');
+    if (!fill) return;
+
+    if (state.indeterminate) {
+      fill.style.removeProperty('width');
+      return;
+    }
+
+    fill.style.width = `${(state.ratio * 100).toFixed(3)}%`;
+  }
+
+  #syncCircular(state: ProgressState): void {
+    const svg = getRef<SVGElement>(this, 'circular-svg');
+    const track = getRef<SVGCircleElement>(this, 'circular-track');
+    const fill = getRef<SVGCircleElement>(this, 'circular-fill');
+    if (!svg || !track || !fill) return;
+
+    const circumferenceText = CIRCULAR_CIRCUMFERENCE.toFixed(3);
+    svg.style.setProperty('--_dads-progress-circumference', circumferenceText);
+
+    track.style.strokeDasharray = circumferenceText;
+    fill.style.strokeDasharray = circumferenceText;
+
+    if (state.indeterminate) {
+      fill.style.strokeDashoffset = (CIRCULAR_CIRCUMFERENCE * 0.95).toFixed(3);
+      return;
+    }
+
+    fill.style.strokeDashoffset = (CIRCULAR_CIRCUMFERENCE * (1 - state.ratio)).toFixed(3);
+  }
+
+  #syncSegments(state: ProgressState): void {
+    const segmentsEl = getRef<HTMLElement>(this, 'segments');
+    if (!segmentsEl) return;
+
+    const count = state.segmentCount;
+    const nodes = this.#ensureSegmentNodes(segmentsEl, count);
+    segmentsEl.style.gridTemplateColumns = `repeat(${count}, minmax(0, 1fr))`;
+
+    const filledThreshold = state.indeterminate ? count : state.filledSegments;
+    for (let i = 0; i < nodes.length; i += 1) {
+      nodes[i].setAttribute('data-filled', i < filledThreshold ? 'true' : 'false');
+    }
+  }
+
+  #ensureSegmentNodes(container: HTMLElement, count: number): HTMLElement[] {
+    const nodes = Array.from(container.querySelectorAll<HTMLElement>('[part="segment"]'));
+
+    if (nodes.length < count) {
+      const fragment = document.createDocumentFragment();
+      for (let i = nodes.length; i < count; i += 1) {
+        const segment = document.createElement('span');
+        segment.setAttribute('part', 'segment');
+        segment.setAttribute('data-filled', 'false');
+
+        const fill = document.createElement('span');
+        fill.setAttribute('part', 'segment-fill');
+
+        segment.append(fill);
+        fragment.append(segment);
+      }
+      container.append(fragment);
+    }
+
+    if (nodes.length > count) {
+      for (let i = nodes.length - 1; i >= count; i -= 1) {
+        nodes[i].remove();
+      }
+    }
+
+    return Array.from(container.querySelectorAll<HTMLElement>('[part="segment"]'));
+  }
+
+  #syncStatus(state: ProgressState): void {
+    const status = getRef<HTMLElement>(this, 'status');
+    if (!status) return;
+
+    if (state.statusLive === 'off') {
+      status.removeAttribute('aria-live');
+      status.removeAttribute('aria-atomic');
+      status.textContent = '';
+      this.#lastStatusKey = null;
+      this.#lastStatusMessage = null;
+      return;
+    }
+
+    status.setAttribute('aria-live', state.statusLive);
+    status.setAttribute('aria-atomic', 'true');
+
+    const statusChanged = state.statusKey !== this.#lastStatusKey;
+    this.#lastStatusKey = state.statusKey;
+
+    if (!statusChanged) return;
+    if (state.ariaValueText === this.#lastStatusMessage) return;
+
+    status.textContent = state.ariaValueText;
+    this.#lastStatusMessage = state.ariaValueText;
+  }
+}

--- a/registry/install-registry.json
+++ b/registry/install-registry.json
@@ -415,6 +415,18 @@
         "componentDir": "packages/components/page-navigation"
       }
     },
+    "progress": {
+      "id": "progress",
+      "tags": [
+        "dads-progress"
+      ],
+      "define": "defineProgress",
+      "call": "prefix-registry",
+      "deps": [],
+      "source": {
+        "componentDir": "packages/components/progress"
+      }
+    },
     "radio": {
       "id": "radio",
       "tags": [
@@ -583,6 +595,7 @@
     "dads-mobile-mock": "mobile-mock",
     "dads-notification-banner": "notification-banner",
     "dads-page-navigation": "page-navigation",
+    "dads-progress": "progress",
     "dads-radio": "radio",
     "dads-search-box": "search-box",
     "dads-select": "select",

--- a/src/demos/showcase-components.ts
+++ b/src/demos/showcase-components.ts
@@ -5904,6 +5904,238 @@ ${dadsDataRows(6, 6)}
     </script>
   `,
 
+  progress: () => `
+    <div style="padding: 40px; max-width: 1120px; margin: 0 auto;">
+      <h2 style="font-size: 28px; margin-bottom: 20px; color: #333;">プログレス</h2>
+      <p style="color: #666; margin-bottom: 32px;">
+        <code>linear / circular / segmented</code> を1コンポーネントで切り替える進捗表示です。
+        既定の <code>status-live</code> は <code>off</code> で、必要時のみ通知できます。
+      </p>
+
+      <section style="margin-bottom: 40px;">
+        <h3 style="font-size: 20px; margin-bottom: 16px; color: #333;">Preview</h3>
+        <div style="display: grid; gap: 20px;">
+          <div style="padding: 16px; border: 1px solid #e5e7eb; border-radius: 12px;">
+            <dads-progress shape="linear" value="68" aria-label="申請手続きの進捗">
+              <span slot="label">申請手続き</span>
+            </dads-progress>
+          </div>
+          <div style="padding: 16px; border: 1px solid #e5e7eb; border-radius: 12px;">
+            <dads-progress shape="circular" size="lg" value="42" aria-label="書類確認の進捗"></dads-progress>
+          </div>
+          <div style="padding: 16px; border: 1px solid #e5e7eb; border-radius: 12px;">
+            <dads-progress
+              shape="segmented"
+              segment-mode="steps"
+              current-step="4"
+              total-steps="7"
+              aria-label="審査工程の進捗"
+            >
+              <span slot="label">審査工程</span>
+              <span slot="value-text">4 / 7</span>
+            </dads-progress>
+          </div>
+        </div>
+      </section>
+
+      <section style="margin-bottom: 40px;">
+        <h3 style="font-size: 20px; margin-bottom: 16px; color: #333;">API / Controls（Storybook風）</h3>
+        <p style="font-size: 14px; color: #666; margin: 0 0 16px;">
+          shapeや値を操作して、ARIA値・見た目・通知設定を確認できます。
+        </p>
+
+        ${renderApiPanelWrapper({
+          imports: [
+            'dads-progress',
+          ],
+          body: `
+            <div>
+              <h4 class="wc-api-panel__section-title">Preview</h4>
+              <div style="padding: 24px; border: 1px dashed #e5e7eb; border-radius: 12px;">
+                <dads-progress
+                  data-api-target
+                  shape="linear"
+                  size="md"
+                  min="0"
+                  max="100"
+                  value="68"
+                  segment-mode="ratio"
+                  segments="10"
+                  current-step="0"
+                  total-steps="1"
+                  status-live="off"
+                  aria-label="進捗"
+                >
+                  <span slot="label">進捗</span>
+                </dads-progress>
+              </div>
+              <div style="margin-top: 16px;">
+                <h4 class="wc-api-panel__section-title">Usage (HTML)</h4>
+                <dads-code-block data-api-code>
+                  <template>
+                    <dads-progress
+                      shape="linear"
+                      size="md"
+                      min="0"
+                      max="100"
+                      value="68"
+                      segment-mode="ratio"
+                      segments="10"
+                      current-step="0"
+                      total-steps="1"
+                      status-live="off"
+                      aria-label="進捗"
+                    >
+                      <span slot="label">進捗</span>
+                    </dads-progress>
+                  </template>
+                </dads-code-block>
+              </div>
+            </div>
+
+            <div class="wc-api-panel__tables">
+              <div>
+                <h4 class="wc-api-panel__section-title">Props / Attrs</h4>
+                <dads-table>
+                  <table class="wc-api-table" data-cell-border="bottom">
+                    ${API_TABLE_PROPS_WITH_TYPE_HEADER}
+                    <tbody>
+                      <tr>
+                        <th scope="row"><code>shape</code></th>
+                        <td><code>attr</code></td>
+                        <td><code>'linear' | 'circular' | 'segmented'</code></td>
+                        <td><code>linear</code></td>
+                        <td><div class="wc-api-control"><select aria-label="shape" data-api-attr="shape" data-default="linear"><option value="linear" selected>linear</option><option value="circular">circular</option><option value="segmented">segmented</option></select></div></td>
+                        <td>表示形状</td>
+                      </tr>
+                      <tr>
+                        <th scope="row"><code>size</code></th>
+                        <td><code>attr</code></td>
+                        <td><code>'sm' | 'md' | 'lg'</code></td>
+                        <td><code>md</code></td>
+                        <td><div class="wc-api-control"><select aria-label="size" data-api-attr="size" data-default="md"><option value="sm">sm</option><option value="md" selected>md</option><option value="lg">lg</option></select></div></td>
+                        <td>サイズ</td>
+                      </tr>
+                      <tr>
+                        <th scope="row"><code>min</code></th>
+                        <td><code>attr</code></td>
+                        <td><code>number</code></td>
+                        <td><code>0</code></td>
+                        <td><div class="wc-api-control"><dads-input-text label="min" value="0" data-api-attr="min" data-default="0"></dads-input-text></div></td>
+                        <td>最小値</td>
+                      </tr>
+                      <tr>
+                        <th scope="row"><code>max</code></th>
+                        <td><code>attr</code></td>
+                        <td><code>number</code></td>
+                        <td><code>100</code></td>
+                        <td><div class="wc-api-control"><dads-input-text label="max" value="100" data-api-attr="max" data-default="100"></dads-input-text></div></td>
+                        <td>最大値</td>
+                      </tr>
+                      <tr>
+                        <th scope="row"><code>value</code></th>
+                        <td><code>attr</code></td>
+                        <td><code>number</code></td>
+                        <td><code>68</code></td>
+                        <td><div class="wc-api-control"><dads-input-text label="value" value="68" data-api-attr="value" data-default="68"></dads-input-text></div></td>
+                        <td>現在値（determinate時）</td>
+                      </tr>
+                      <tr>
+                        <th scope="row"><code>indeterminate</code></th>
+                        <td><code>attr</code></td>
+                        <td><code>boolean</code></td>
+                        <td><code>false</code></td>
+                        <td><div class="wc-api-control"><dads-switch aria-label="indeterminate" data-api-attr="indeterminate" data-default="false"><span slot="label-left">Off</span><span slot="label-right">On</span></dads-switch></div></td>
+                        <td>不確定状態（aria-valuenowを外す）</td>
+                      </tr>
+                      <tr>
+                        <th scope="row"><code>status-live</code></th>
+                        <td><code>attr</code></td>
+                        <td><code>'off' | 'polite' | 'assertive'</code></td>
+                        <td><code>off</code></td>
+                        <td><div class="wc-api-control"><select aria-label="status-live" data-api-attr="status-live" data-default="off"><option value="off" selected>off</option><option value="polite">polite</option><option value="assertive">assertive</option></select></div></td>
+                        <td>live通知レベル</td>
+                      </tr>
+                      <tr>
+                        <th scope="row"><code>value-text</code></th>
+                        <td><code>attr</code></td>
+                        <td><code>string</code></td>
+                        <td><code>(unset)</code></td>
+                        <td><div class="wc-api-control"><dads-input-text label="value-text" value="" data-api-attr="value-text" data-default=""></dads-input-text></div></td>
+                        <td>aria-valuetext / 可視値の明示上書き</td>
+                      </tr>
+                      <tr>
+                        <th scope="row"><code>segment-mode</code></th>
+                        <td><code>attr</code></td>
+                        <td><code>'ratio' | 'steps'</code></td>
+                        <td><code>ratio</code></td>
+                        <td><div class="wc-api-control"><select aria-label="segment-mode" data-api-attr="segment-mode" data-default="ratio"><option value="ratio" selected>ratio</option><option value="steps">steps</option></select></div></td>
+                        <td>segmented の表示モード</td>
+                      </tr>
+                      <tr>
+                        <th scope="row"><code>segments</code></th>
+                        <td><code>attr</code></td>
+                        <td><code>integer</code></td>
+                        <td><code>10</code></td>
+                        <td><div class="wc-api-control"><dads-input-text label="segments" value="10" data-api-attr="segments" data-default="10"></dads-input-text></div></td>
+                        <td>ratioモード時の分割数（2..100）</td>
+                      </tr>
+                      <tr>
+                        <th scope="row"><code>current-step</code></th>
+                        <td><code>attr</code></td>
+                        <td><code>integer</code></td>
+                        <td><code>0</code></td>
+                        <td><div class="wc-api-control"><dads-input-text label="current-step" value="0" data-api-attr="current-step" data-default="0"></dads-input-text></div></td>
+                        <td>stepsモード時の現在ステップ</td>
+                      </tr>
+                      <tr>
+                        <th scope="row"><code>total-steps</code></th>
+                        <td><code>attr</code></td>
+                        <td><code>integer</code></td>
+                        <td><code>1</code></td>
+                        <td><div class="wc-api-control"><dads-input-text label="total-steps" value="1" data-api-attr="total-steps" data-default="1"></dads-input-text></div></td>
+                        <td>stepsモード時の総ステップ（1..100）</td>
+                      </tr>
+                      <tr>
+                        <th scope="row"><code>aria-label</code></th>
+                        <td><code>attr</code></td>
+                        <td><code>string</code></td>
+                        <td><code>進捗</code></td>
+                        <td><div class="wc-api-control"><dads-input-text label="aria-label" value="進捗" data-api-attr="aria-label" data-default="進捗"></dads-input-text></div></td>
+                        <td>内部 progressbar の名称</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </dads-table>
+              </div>
+
+              <div>
+                <h4 class="wc-api-panel__section-title">CSS vars</h4>
+                <dads-table>
+                  <table class="wc-api-table" data-cell-border="bottom">
+                    ${API_TABLE_CSS_VARS_HEADER}
+                    <tbody>
+                      <tr><th scope="row"><code>--dads-progress-track-color</code></th><td><code>--color-neutral-solid-gray-100</code></td><td><div class="wc-api-control"><dads-input-text label="--dads-progress-track-color" value="" data-api-css-var="--dads-progress-track-color" data-default=""></dads-input-text></div></td><td>トラック色</td></tr>
+                      <tr><th scope="row"><code>--dads-progress-fill-color</code></th><td><code>--color-primary</code></td><td><div class="wc-api-control"><dads-input-text label="--dads-progress-fill-color" value="" data-api-css-var="--dads-progress-fill-color" data-default=""></dads-input-text></div></td><td>進捗色</td></tr>
+                      <tr><th scope="row"><code>--dads-progress-height</code></th><td><code>(size token)</code></td><td><div class="wc-api-control"><dads-input-text label="--dads-progress-height" value="" data-api-css-var="--dads-progress-height" data-default=""></dads-input-text></div></td><td>linear / segmented 高さ</td></tr>
+                      <tr><th scope="row"><code>--dads-progress-radius</code></th><td><code>9999px</code></td><td><div class="wc-api-control"><dads-input-text label="--dads-progress-radius" value="" data-api-css-var="--dads-progress-radius" data-default=""></dads-input-text></div></td><td>角丸</td></tr>
+                      <tr><th scope="row"><code>--dads-progress-size</code></th><td><code>(size token)</code></td><td><div class="wc-api-control"><dads-input-text label="--dads-progress-size" value="" data-api-css-var="--dads-progress-size" data-default=""></dads-input-text></div></td><td>circular 直径</td></tr>
+                      <tr><th scope="row"><code>--dads-progress-stroke-width</code></th><td><code>(size token)</code></td><td><div class="wc-api-control"><dads-input-text label="--dads-progress-stroke-width" value="" data-api-css-var="--dads-progress-stroke-width" data-default=""></dads-input-text></div></td><td>circular 線幅</td></tr>
+                      <tr><th scope="row"><code>--dads-progress-segment-gap</code></th><td><code>4px</code></td><td><div class="wc-api-control"><dads-input-text label="--dads-progress-segment-gap" value="" data-api-css-var="--dads-progress-segment-gap" data-default=""></dads-input-text></div></td><td>segmented 区画間隔</td></tr>
+                      <tr><th scope="row"><code>--dads-progress-animation-duration</code></th><td><code>1.2s</code></td><td><div class="wc-api-control"><dads-input-text label="--dads-progress-animation-duration" value="" data-api-css-var="--dads-progress-animation-duration" data-default=""></dads-input-text></div></td><td>アニメーション時間</td></tr>
+                      <tr><th scope="row"><code>--dads-progress-label-color</code></th><td><code>--color-neutral-solid-gray-800</code></td><td><div class="wc-api-control"><dads-input-text label="--dads-progress-label-color" value="" data-api-css-var="--dads-progress-label-color" data-default=""></dads-input-text></div></td><td>ラベル色</td></tr>
+                      <tr><th scope="row"><code>--dads-progress-value-color</code></th><td><code>--color-neutral-solid-gray-700</code></td><td><div class="wc-api-control"><dads-input-text label="--dads-progress-value-color" value="" data-api-css-var="--dads-progress-value-color" data-default=""></dads-input-text></div></td><td>値テキスト色</td></tr>
+                    </tbody>
+                  </table>
+                </dads-table>
+                ${API_TABLE_CSS_VARS_NOTE}
+              </div>
+            </div>
+          `,
+        })}
+      </section>
+    </div>
+  `,
 
   switch: () => `
     <div style="padding: 40px; max-width: 1280px; margin: 0 auto;">

--- a/viewer.html
+++ b/viewer.html
@@ -68,6 +68,7 @@
       "dads-language-selector": "/@components/dads/language-selector.js",
       "dads-page-navigation": "/@components/dads/page-navigation.js",
       "dads-carousel": "/@components/dads/carousel.js",
+      "dads-progress": "/@components/dads/progress.js",
       "dads-breadcrumb": "/@components/dads/breadcrumb.js",
       "dads-breadcrumb-item": "/@components/dads/breadcrumb-item.js",
       "dads-utility-link": "/@components/dads/utility-link.js",
@@ -467,6 +468,7 @@
             <option value="menuListBoxFidelity">メニューリストボックス（忠実度検証）</option>
             <option value="switch">スイッチ</option>
             <option value="carousel">カルーセル</option>
+            <option value="progress">プログレス</option>
             <option value="stepNavigation">ステップナビゲーション</option>
             <option value="resetCss">リセットCSS比較デモ（独自）</option>
           </select>
@@ -685,7 +687,8 @@
       '/@components/dads/utility-link.js',
       '/@components/dads/language-selector.js',
       '/@components/dads/notification-banner.js',
-      '/@components/dads/carousel.js'
+      '/@components/dads/carousel.js',
+      '/@components/dads/progress.js'
     ];
 
     // クリティカルコンポーネントを即座にロード


### PR DESCRIPTION
## Summary
- `dads-progress` を新規追加し、`linear` / `circular` / `segmented` を単一コンポーネントAPIで提供
- `segment-mode="ratio|steps"` を実装し、`segments` と `current-step/total-steps` の両方に対応
- ARIA整合（determinate/indeterminate）と `status-live`（default: `off`）の通知制御を実装
- Viewer に `progress` デモ、API/Controls、Usage を追加
- CEM / registry / a11y annotations を更新

## Changed Files
- 追加: `packages/components/progress/*`
- 追加: `packages/autoload/dads/progress.ts`
- 更新: `packages/components/index.ts`
- 更新: `src/demos/showcase-components.ts`
- 更新: `viewer.html`
- 更新: `docs/knowledge/a11y-annotations.json`
- 更新: `custom-elements.json`
- 更新: `registry/install-registry.json`
- 更新: `docs/knowledge/learnings.md`

## Validation
- `npm run agents:verify` ✅
  - `cem:analyze` ✅
  - `contracts:check` ✅
  - `registry:generate` / `registry:check` ✅
  - `validate:wc` ✅
  - `type-check` ✅
  - `test:run` ✅
  - `build` ✅

## Notes
- `status-live` の既定値は `off` です。
- `aria-label` / `aria-labelledby` は内部 `progressbar` 要素へ転送されます。
