### PR TITLE
docs: standardize GovUI pattern issue contracts

### DIFF
--- a/docs/knowledge/ai-consumption.md
+++ b/docs/knowledge/ai-consumption.md
@@ -90,3 +90,16 @@ npm run mcp:design-system
 
 不足起票テンプレートは `.github/ISSUE_TEMPLATE/dads-template-gap.yml` です。  
 ラベルは `enhancement` のみで起票します。
+
+## 7) GovUI Pattern Issue の引き継ぎルール
+
+GovUI テンプレート群（`gov-*`）を AI に実装させる場合、Issue 本文の情報密度がそのまま実装品質に影響します。
+`#106` 配下の Pattern Issue（`#112` から `#126`）は、次の共通契約を前提に扱ってください。
+
+- 認証方式の列挙値は `municipal | e-gov | myna` で統一する。
+- 申請状態辞書は次を共通語彙として再利用する。  
+  `draft, in_progress, submitted, under_review, needs_fix, needs_resubmission, failed, completed, rejected, withdrawn, expired`
+- Pattern Issue には「UI要件（セクション順）」「API/状態契約」「a11y要件」「受け入れ条件（挙動）」を必ず含める。
+- 実装前の最小検証は `patterns:check` / `validate:wc` / `validate:templates:quick` / `templates:gaps:dry-run` を使う。
+
+この契約は、テンプレートの再現性と cross-pattern 整合を維持するための運用上の Source of Truth とする。

--- a/docs/rules/template-development-workflow.md
+++ b/docs/rules/template-development-workflow.md
@@ -98,3 +98,40 @@ npm run templates:gaps:create
 
 - エスカレーションissueテンプレート: `.github/ISSUE_TEMPLATE/dads-template-gap.yml`
 - テンプレートgap収集 CLI: `scripts/dads-template/cli.js`
+
+## 7) GovUI Pattern Issue 標準（#106 系）
+
+GovUI テンプレート（`gov-*`）の Issue を新規作成・更新するときは、以下を必須項目として固定する。
+
+### 7.1 必須セクション
+
+- 背景（調査反映）
+- 目的
+- 非ゴール
+- 想定URL
+- 依存関係（先行/後続）
+- 実装対象ファイル（絶対パス）
+- 利用コンポーネント（想定）
+- UI要件（必須セクション順）
+- API/状態/バリデーション契約
+- アクセシビリティ要件
+- 実装制約（#104準拠）
+- 検証コマンド
+- 受け入れ条件（挙動ベース）
+- 参考（一次情報URL）
+
+### 7.2 共通固定値
+
+- 認証方式（初期対象）: `municipal | e-gov | myna`
+- 申請状態辞書（共通）:
+  `draft, in_progress, submitted, under_review, needs_fix, needs_resubmission, failed, completed, rejected, withdrawn, expired`
+- Pattern Issue の最低検証コマンド:
+  - `npm run patterns:check`
+  - `npm run validate:wc`
+  - `npm run validate:templates:quick`
+  - `npm run templates:gaps:dry-run`
+
+### 7.3 運用メモ
+
+- 本文が短い場合は「実装者が迷わない粒度」になるまで具体化してから着手する。
+- 複数 Pattern を同時に更新した場合は、状態辞書と認証方式の整合を横断確認する。


### PR DESCRIPTION
## Summary
- add GovUI Pattern Issue standards to template workflow docs
- document common contract for `#106` pattern issues (`#112`-`#126`) in AI consumption guide
- fix handoff quality by codifying required sections, shared enums, and minimum validation commands

## Changes
- `/Users/reiharada/.codex/worktrees/50f4/web-components-factory/docs/rules/template-development-workflow.md`
  - add `## 7) GovUI Pattern Issue 標準（#106 系）`
  - define required issue sections, fixed auth/status values, and baseline checks
- `/Users/reiharada/.codex/worktrees/50f4/web-components-factory/docs/knowledge/ai-consumption.md`
  - add `## 7) GovUI Pattern Issue の引き継ぎルール`
  - align AI handoff rules with the same contract

## Validation
- `npm run wcf:docs:check`
- `npm run patterns:check`
