### PR TITLE
fix(tab): keep keyboard model and focus ring radius

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -48333,6 +48333,10 @@
             {
               "description": "フォーカスリング色",
               "name": "--dads-tab-focus-ring-color"
+            },
+            {
+              "description": "フォーカスリングの角丸",
+              "name": "--dads-tab-focus-border-radius"
             }
           ],
           "cssParts": [
@@ -48368,6 +48372,24 @@
             }
           ],
           "members": [
+            {
+              "kind": "method",
+              "name": "#activateTab",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "tab",
+                  "type": {
+                    "text": "HTMLButtonElement"
+                  }
+                }
+              ]
+            },
             {
               "kind": "field",
               "name": "#childObserver",
@@ -48421,6 +48443,16 @@
               }
             },
             {
+              "kind": "method",
+              "name": "#focusActivePanel",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
               "kind": "field",
               "name": "#fontState",
               "privacy": "private",
@@ -48468,6 +48500,16 @@
               "return": {
                 "type": {
                   "text": "HTMLElement[]"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "#getSelectedIndex",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "number"
                 }
               }
             },
@@ -48912,9 +48954,11 @@
                   "aria-controls と aria-labelledby を使って、タブとパネルを1対1で関連付けます。"
                 ],
                 "keyboard": [
-                  "Tab / Shift+Tab ではタブリスト外へフォーカスを移し、タブ間移動は Arrow / Home / End を使用します。",
-                  "Arrow / Home / End でタブ移動できます。orientation=\"left|right\" では ArrowUp / ArrowDown を使用します。",
-                  "activation-mode=\"manual\" では Enter / Space で選択を確定し、フォーカスはタブに留まります。"
+                  "Tab / Shift+Tab でタブ（role=\"tab\"）へフォーカス移動できます。",
+                  "Arrow / Home / End でタブ間移動できます。data-tab-disabled はスキップします。orientation=\"left|right\" では ArrowUp / ArrowDown を使用します。",
+                  "activation-mode=\"auto\" では Arrow によるフォーカス移動と同時に選択が変わります。",
+                  "activation-mode=\"manual\" では Space で選択を確定します。",
+                  "Enter で選択中タブのパネルへフォーカスを移動します（manual では選択確定後に移動）。"
                 ],
                 "zoom": [
                   "orientation=\"top|bottom|left|right\" でレイアウトを切り替えます。",
@@ -48950,7 +48994,7 @@
                   "id": "active-tab",
                   "title": "選択中タブ",
                   "label": "role=\"tab\"",
-                  "description": "現在選択されているタブです。aria-selected=\"true\" と roving tabindex の起点を持ちます。",
+                  "description": "現在選択されているタブです。aria-selected=\"true\" を持ち、対応パネルは aria-controls で関連付けられます。",
                   "category": "states",
                   "placement": "top-right",
                   "target": {
@@ -48964,7 +49008,7 @@
                   "label": "part=\"indicator\"",
                   "description": "選択中タブを示す視覚インジケーターです。",
                   "category": "states",
-                  "placement": "top-right",
+                  "placement": "bottom-left",
                   "target": {
                     "scope": "shadow",
                     "selector": "[part=\"tab\"][aria-selected=\"true\"] [part=\"indicator\"]"
@@ -48988,7 +49032,7 @@
                   "label": "role=\"tabpanel\"",
                   "description": "選択中タブに対応するパネルコンテンツです。",
                   "category": "semantics",
-                  "placement": "bottom-left",
+                  "placement": "bottom-right",
                   "target": {
                     "scope": "light",
                     "selector": "[role=\"tabpanel\"]:not([hidden])"
@@ -65110,7 +65154,7 @@
         {
           "kind": "variable",
           "name": "tabStyles",
-          "default": "css` :host { display: block; min-inline-size: 0; color: var(--dads-tab-color); font-family: var(--font-family-sans); } :host([hidden]) { display: none; } [part=\"base\"] { display: flex; flex-direction: column; min-inline-size: 0; } [part=\"tablist\"] { position: relative; z-index: 2; display: flex; flex-wrap: wrap; align-items: stretch; inline-size: 100%; margin: 0 0 -1px; padding: 0 1px 0 0; } #default-slot { z-index: 1; display: block; box-sizing: border-box; min-inline-size: 0; min-block-size: var(--_dads-tab-tablist-block-size, 0px); border: 1px solid var(--dads-tab-border-color); background: var(--tab-bg-panel); padding: var(--tab-panel-padding); color: var(--tab-panel-color); font-size: var(--tab-panel-font-size); font-weight: var(--tab-panel-font-weight); line-height: var(--tab-panel-line-height); letter-spacing: var(--tab-panel-letter-spacing); } [part~=\"tab\"] { --_dads-tab-background: var(--dads-tab-background); --_dads-tab-indicator-color: var(--tab-indicator-idle); --_dads-tab-label-decoration: none; position: relative; box-sizing: border-box; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 0; margin: 0 -1px 0 0; border: 1px solid var(--dads-tab-border-color); background: var(--_dads-tab-background); padding: 0; color: var(--dads-tab-color); font-family: var(--font-family-sans); font-size: var(--font-size-16, 1rem); font-weight: var(--font-weight-400, 400); line-height: var(--line-height-120, 1.2); letter-spacing: 0; white-space: nowrap; cursor: pointer; } [part~=\"tab\"]:focus { outline: none; } [part~=\"tab\"]:focus-visible { z-index: 3; } /* DADSフォーカスリングは維持しつつ、タブ面は塗りつぶさない */ :host button[part~=\"tab\"][role=\"tab\"]:focus-visible { background: var(--_dads-tab-background); } [part~=\"indicator\"] { display: block; inline-size: 100%; block-size: var(--dads-tab-indicator-height); background: var(--_dads-tab-indicator-color); flex: 0 0 auto; } [part~=\"label\"] { display: flex; align-items: center; justify-content: center; padding: var(--tab-padding-y) var(--tab-padding-x); color: inherit; font: inherit; line-height: inherit; letter-spacing: inherit; text-align: center; text-decoration: var(--_dads-tab-label-decoration); text-decoration-thickness: var(--tab-underline-thickness); text-underline-offset: var(--tab-underline-offset); } [part~=\"tab\"][aria-selected=\"true\"] { --_dads-tab-indicator-color: var(--dads-tab-indicator-color); color: var(--dads-tab-color-selected); font-weight: var(--font-weight-700, 700); z-index: 2; } :host([orientation=\"top\"]) [part~=\"tab\"][aria-selected=\"true\"] { border-top: 0; border-right: 1px solid var(--dads-tab-border-color); border-bottom: 0; border-left: 1px solid var(--dads-tab-border-color); } :host([orientation=\"top\"]) [part~=\"tab\"][aria-selected=\"true\"]::before { content: ''; position: absolute; inset-block-start: 0; inset-inline-start: -1px; inline-size: calc(100% + 2px); block-size: var(--dads-tab-indicator-height); background: var(--dads-tab-indicator-color); pointer-events: none; } :host([orientation=\"top\"]) [part~=\"tab\"][aria-selected=\"true\"] [part~=\"indicator\"] { background: transparent; } [part~=\"tab\"][aria-disabled=\"true\"] { color: var(--dads-tab-color-disabled); cursor: not-allowed; } @media (any-hover: hover) { [part~=\"tab\"]:not([aria-selected=\"true\"]):not([aria-disabled=\"true\"]):hover { --_dads-tab-background: var(--dads-tab-background-hover); --_dads-tab-label-decoration: underline; } [part~=\"tab\"]:not([aria-selected=\"true\"]):not([aria-disabled=\"true\"]):hover { --_dads-tab-indicator-color: var(--dads-tab-border-color); } } ::slotted([part~=\"tabpanel\"]) { display: block; box-sizing: border-box; margin: 0; border: 0; padding: 0; color: inherit; font: inherit; letter-spacing: inherit; } ::slotted([part~=\"tabpanel\"][hidden]) { display: none; } :host([orientation=\"bottom\"]) [part=\"base\"] { flex-direction: column-reverse; } :host([orientation=\"bottom\"]) [part=\"tablist\"] { margin: -1px 0 0; } :host([orientation=\"bottom\"]) [part~=\"tab\"] { flex-direction: column-reverse; } :host([orientation=\"bottom\"]) [part~=\"tab\"][aria-selected=\"true\"] { border-top: 0; border-right: 1px solid var(--dads-tab-border-color); border-bottom: 0; border-left: 1px solid var(--dads-tab-border-color); } :host([orientation=\"bottom\"]) [part~=\"tab\"][aria-selected=\"true\"]::after { content: ''; position: absolute; inset-block-end: 0; inset-inline-start: -1px; inline-size: calc(100% + 2px); block-size: var(--dads-tab-indicator-height); background: var(--dads-tab-indicator-color); pointer-events: none; } :host([orientation=\"bottom\"]) [part~=\"tab\"][aria-selected=\"true\"] [part~=\"indicator\"] { background: transparent; } :host([orientation=\"left\"]) [part=\"base\"] { flex-direction: row; } :host([orientation=\"left\"]) [part=\"tablist\"] { align-self: stretch; inline-size: var(--tab-vertical-list-width); flex-direction: column; flex-wrap: nowrap; margin: 0 -1px 0 0; padding: 0 0 1px; } :host([orientation=\"left\"]) [part~=\"tab\"] { inline-size: 100%; flex-direction: row; justify-content: flex-start; gap: var(--tab-label-gap-vertical); margin: 0 0 -1px; } :host([orientation=\"left\"]) [part~=\"label\"] { flex: 1 1 auto; justify-content: flex-start; text-align: left; } :host([orientation=\"left\"]) [part~=\"indicator\"] { inline-size: var(--dads-tab-indicator-height); block-size: auto; align-self: stretch; } :host([orientation=\"left\"]) [part~=\"tab\"][aria-selected=\"true\"] { border-top: 1px solid var(--dads-tab-border-color); border-right: 0; border-bottom: 1px solid var(--dads-tab-border-color); border-left: 0; } :host([orientation=\"left\"]) #default-slot { flex: 1 1 auto; min-inline-size: 0; } :host([orientation=\"right\"]) [part=\"base\"] { flex-direction: row-reverse; } :host([orientation=\"right\"]) [part=\"tablist\"] { align-self: stretch; inline-size: var(--tab-vertical-list-width); flex-direction: column; flex-wrap: nowrap; margin: 0 0 0 -1px; padding: 0 0 1px; } :host([orientation=\"right\"]) [part~=\"tab\"] { inline-size: 100%; flex-direction: row-reverse; justify-content: flex-start; gap: var(--tab-label-gap-vertical); margin: 0 0 -1px; } :host([orientation=\"right\"]) [part~=\"label\"] { flex: 1 1 auto; justify-content: flex-start; text-align: left; } :host([orientation=\"right\"]) [part~=\"indicator\"] { inline-size: var(--dads-tab-indicator-height); block-size: auto; align-self: stretch; } :host([orientation=\"right\"]) [part~=\"tab\"][aria-selected=\"true\"] { border-top: 1px solid var(--dads-tab-border-color); border-right: 0; border-bottom: 1px solid var(--dads-tab-border-color); border-left: 0; } :host([orientation=\"right\"]) #default-slot { flex: 1 1 auto; min-inline-size: 0; } @media (prefers-reduced-motion: reduce) { [part~=\"tab\"] { transition: none; } } @media (forced-colors: active) { [part~=\"tab\"] { border-color: ButtonText; color: ButtonText; } [part~=\"tab\"][aria-selected=\"true\"] [part~=\"indicator\"] { background: Highlight; } [part~=\"tab\"][aria-disabled=\"true\"] { color: GrayText; } #default-slot { border-color: ButtonText; } } `"
+          "default": "css` :host { display: block; min-inline-size: 0; color: var(--dads-tab-color); font-family: var(--font-family-sans); } :host([hidden]) { display: none; } [part=\"base\"] { display: flex; flex-direction: column; min-inline-size: 0; } [part=\"tablist\"] { position: relative; z-index: 2; display: flex; flex-wrap: wrap; align-items: stretch; inline-size: 100%; margin: 0 0 -1px; padding: 0 1px 0 0; } #default-slot { z-index: 1; display: block; box-sizing: border-box; min-inline-size: 0; min-block-size: var(--_dads-tab-tablist-block-size, 0px); border: 1px solid var(--dads-tab-border-color); background: var(--tab-bg-panel); padding: var(--tab-panel-padding); color: var(--tab-panel-color); font-size: var(--tab-panel-font-size); font-weight: var(--tab-panel-font-weight); line-height: var(--tab-panel-line-height); letter-spacing: var(--tab-panel-letter-spacing); } [part~=\"tab\"] { --_dads-tab-background: var(--dads-tab-background); --_dads-tab-indicator-color: var(--tab-indicator-idle); --_dads-tab-label-decoration: none; position: relative; box-sizing: border-box; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 0; margin: 0 -1px 0 0; border: 1px solid var(--dads-tab-border-color); background: var(--_dads-tab-background); padding: 0; color: var(--dads-tab-color); font-family: var(--font-family-sans); font-size: var(--font-size-16, 1rem); font-weight: var(--font-weight-400, 400); line-height: var(--line-height-120, 1.2); letter-spacing: 0; white-space: nowrap; cursor: pointer; } [part~=\"tab\"]:focus { outline: none; } [part~=\"tab\"]:focus-visible { z-index: 3; border-radius: var(--dads-tab-focus-border-radius); } /* DADSフォーカスリングは維持しつつ、タブ面は塗りつぶさない */ :host button[part~=\"tab\"][role=\"tab\"]:focus-visible { background: var(--_dads-tab-background); } [part~=\"indicator\"] { display: block; inline-size: 100%; block-size: var(--dads-tab-indicator-height); background: var(--_dads-tab-indicator-color); flex: 0 0 auto; } [part~=\"label\"] { display: flex; align-items: center; justify-content: center; padding: var(--tab-padding-y) var(--tab-padding-x); color: inherit; font: inherit; line-height: inherit; letter-spacing: inherit; text-align: center; text-decoration: var(--_dads-tab-label-decoration); text-decoration-thickness: var(--tab-underline-thickness); text-underline-offset: var(--tab-underline-offset); } [part~=\"tab\"][aria-selected=\"true\"] { --_dads-tab-indicator-color: var(--dads-tab-indicator-color); color: var(--dads-tab-color-selected); font-weight: var(--font-weight-700, 700); z-index: 2; } :host([orientation=\"top\"]) [part~=\"tab\"][aria-selected=\"true\"] { border-top: 0; border-right: 1px solid var(--dads-tab-border-color); border-bottom: 0; border-left: 1px solid var(--dads-tab-border-color); } :host([orientation=\"top\"]) [part~=\"tab\"][aria-selected=\"true\"]::before { content: ''; position: absolute; inset-block-start: 0; inset-inline-start: -1px; inline-size: calc(100% + 2px); block-size: var(--dads-tab-indicator-height); background: var(--dads-tab-indicator-color); pointer-events: none; } :host([orientation=\"top\"]) [part~=\"tab\"][aria-selected=\"true\"] [part~=\"indicator\"] { background: transparent; } [part~=\"tab\"][aria-disabled=\"true\"] { color: var(--dads-tab-color-disabled); cursor: not-allowed; } @media (any-hover: hover) { [part~=\"tab\"]:not([aria-selected=\"true\"]):not([aria-disabled=\"true\"]):hover { --_dads-tab-background: var(--dads-tab-background-hover); --_dads-tab-label-decoration: underline; --_dads-tab-indicator-color: var(--dads-tab-border-color); } } ::slotted([part~=\"tabpanel\"]) { display: block; box-sizing: border-box; margin: 0; border: 0; padding: 0; color: inherit; font: inherit; letter-spacing: inherit; } ::slotted([part~=\"tabpanel\"][hidden]) { display: none; } ::slotted([part~=\"tabpanel\"]:focus-visible) { outline: var(--dads-focus-outline-width) solid var(--dads-focus-outline-color); outline-offset: var(--dads-focus-outline-offset); box-shadow: 0 0 0 var(--dads-focus-ring-width) var(--dads-focus-ring-color); border-radius: var(--dads-tab-focus-border-radius); } :host([orientation=\"bottom\"]) [part=\"base\"] { flex-direction: column-reverse; } :host([orientation=\"bottom\"]) [part=\"tablist\"] { margin: -1px 0 0; } :host([orientation=\"bottom\"]) [part~=\"tab\"] { flex-direction: column-reverse; } :host([orientation=\"bottom\"]) [part~=\"tab\"][aria-selected=\"true\"] { border-top: 0; border-right: 1px solid var(--dads-tab-border-color); border-bottom: 0; border-left: 1px solid var(--dads-tab-border-color); } :host([orientation=\"bottom\"]) [part~=\"tab\"][aria-selected=\"true\"]::after { content: ''; position: absolute; inset-block-end: 0; inset-inline-start: -1px; inline-size: calc(100% + 2px); block-size: var(--dads-tab-indicator-height); background: var(--dads-tab-indicator-color); pointer-events: none; } :host([orientation=\"bottom\"]) [part~=\"tab\"][aria-selected=\"true\"] [part~=\"indicator\"] { background: transparent; } :host([orientation=\"left\"]) [part=\"base\"] { flex-direction: row; } :host([orientation=\"left\"]) [part=\"tablist\"] { align-self: stretch; inline-size: var(--tab-vertical-list-width); flex-direction: column; flex-wrap: nowrap; margin: 0 -1px 0 0; padding: 0 0 1px; } :host([orientation=\"left\"]) [part~=\"tab\"] { inline-size: 100%; flex-direction: row; justify-content: flex-start; gap: var(--tab-label-gap-vertical); margin: 0 0 -1px; } :host([orientation=\"left\"]) [part~=\"label\"] { flex: 1 1 auto; justify-content: flex-start; text-align: left; } :host([orientation=\"left\"]) [part~=\"indicator\"] { inline-size: var(--dads-tab-indicator-height); block-size: auto; align-self: stretch; } :host([orientation=\"left\"]) [part~=\"tab\"][aria-selected=\"true\"] { border-top: 1px solid var(--dads-tab-border-color); border-right: 0; border-bottom: 1px solid var(--dads-tab-border-color); border-left: 0; } :host([orientation=\"left\"]) #default-slot { flex: 1 1 auto; min-inline-size: 0; } :host([orientation=\"right\"]) [part=\"base\"] { flex-direction: row-reverse; } :host([orientation=\"right\"]) [part=\"tablist\"] { align-self: stretch; inline-size: var(--tab-vertical-list-width); flex-direction: column; flex-wrap: nowrap; margin: 0 0 0 -1px; padding: 0 0 1px; } :host([orientation=\"right\"]) [part~=\"tab\"] { inline-size: 100%; flex-direction: row-reverse; justify-content: flex-start; gap: var(--tab-label-gap-vertical); margin: 0 0 -1px; } :host([orientation=\"right\"]) [part~=\"label\"] { flex: 1 1 auto; justify-content: flex-start; text-align: left; } :host([orientation=\"right\"]) [part~=\"indicator\"] { inline-size: var(--dads-tab-indicator-height); block-size: auto; align-self: stretch; } :host([orientation=\"right\"]) [part~=\"tab\"][aria-selected=\"true\"] { border-top: 1px solid var(--dads-tab-border-color); border-right: 0; border-bottom: 1px solid var(--dads-tab-border-color); border-left: 0; } :host([orientation=\"right\"]) #default-slot { flex: 1 1 auto; min-inline-size: 0; } @media (prefers-reduced-motion: reduce) { [part~=\"tab\"] { transition: none; } } @media (forced-colors: active) { [part~=\"tab\"] { border-color: ButtonText; color: ButtonText; } [part~=\"tab\"][aria-selected=\"true\"] [part~=\"indicator\"] { background: Highlight; } [part~=\"tab\"][aria-disabled=\"true\"] { color: GrayText; } #default-slot { border-color: ButtonText; } } `"
         }
       ],
       "exports": [

--- a/docs/knowledge/2026-02-25-tab-keyboard-model-focus-ring-postflight.md
+++ b/docs/knowledge/2026-02-25-tab-keyboard-model-focus-ring-postflight.md
@@ -1,0 +1,32 @@
+# 2026-02-25 dads-tab postflight（キーボードモデル維持 + focus ring 角丸トークン）
+
+## Context
+- Feature: `dads-tab` のキーボードモデルを現状維持（Tab 巡回 + Enter で tabpanel へフォーカス移動）しつつ、focus ring の角丸をトークン化して一貫性を確保する。
+- Date: 2026-02-25
+- Scope: `packages/components/tab/**`, `docs/knowledge/a11y-annotations.json`, `custom-elements.json`, `docs/llms/tab.md`, `llms-full.txt`
+
+## What Worked
+- キーボード挙動（Tab/Arrow/Home/End, auto/manual, Enter/Space）に合わせて a11y 注釈を更新し、CEM/LLM docs まで同期できた。
+- `--dads-tab-focus-border-radius` を追加し、`[part~="tab"]:focus-visible` と `::slotted([part~="tabpanel"]:focus-visible)` の角丸を揃えられた。
+- focus ring の色/幅/offset は `--dads-focus-*` を使用して直値を避け、テーマ互換を維持できた。
+
+## What Blocked Progress
+- `npm run agents:pre-pr` の `check-generated-clean` は `custom-elements.json` / `registry/install-registry.json` が HEAD と一致していないと失敗するため、生成物変更を含む場合は「コミット → verify」の順序が必要。
+
+## Root Causes
+- キーボードモデルとドキュメント（a11y annotations / CEM / llms）がズレると、利用者・AI の両方に誤情報が残りやすい。
+- focus ring は複数要素（tab / tabpanel）にまたがるため、角丸の単一ソースがないと視覚的一貫性が崩れやすい。
+
+## New Rules
+- Rule: `dads-tab` のキーボードモデル変更時は `docs/knowledge/a11y-annotations.json` の `dads-tab.categories.keyboard` を同時更新し、`npm run cem:analyze` と `npm run llms:generate` の結果を同PRに含める。
+  - Rationale: 利用者向け注釈と AI 向け参照（CEM/LLM）を常に一致させるため。
+  - Example: `docs/knowledge/a11y-annotations.json`, `custom-elements.json`, `docs/llms/tab.md`, `llms-full.txt`
+- Rule: focus ring の見た目（色/幅/offset）は `--dads-focus-*` と `--dads-tab-focus-border-radius` で定義し、`rgb()/rgba()/#hex` の直値を置かない。
+  - Rationale: テーマ差し替え互換と一貫性を担保するため。
+  - Example: `packages/components/tab/tab-styles.ts`
+
+## Next Time Checklist
+- [ ] タブと tabpanel の focus-visible が同じ角丸で表示される
+- [ ] `rg -n "rgb\\(|rgba\\(|#[0-9a-fA-F]{3,8}" packages/components/tab` が0件
+- [ ] `npm run cem:analyze` / `npm run llms:generate` 実行後に generated clean
+- [ ] `npm run validate:wc` / `npm run test:run -- packages/components/tab/tab.test.ts` が通る

--- a/docs/knowledge/a11y-annotations.json
+++ b/docs/knowledge/a11y-annotations.json
@@ -3301,9 +3301,11 @@
         "aria-controls と aria-labelledby を使って、タブとパネルを1対1で関連付けます。"
       ],
       "keyboard": [
-        "Tab / Shift+Tab ではタブリスト外へフォーカスを移し、タブ間移動は Arrow / Home / End を使用します。",
-        "Arrow / Home / End でタブ移動できます。orientation=\"left|right\" では ArrowUp / ArrowDown を使用します。",
-        "activation-mode=\"manual\" では Enter / Space で選択を確定し、フォーカスはタブに留まります。"
+        "Tab / Shift+Tab でタブ（role=\"tab\"）へフォーカス移動できます。",
+        "Arrow / Home / End でタブ間移動できます。data-tab-disabled はスキップします。orientation=\"left|right\" では ArrowUp / ArrowDown を使用します。",
+        "activation-mode=\"auto\" では Arrow によるフォーカス移動と同時に選択が変わります。",
+        "activation-mode=\"manual\" では Space で選択を確定します。",
+        "Enter で選択中タブのパネルへフォーカスを移動します（manual では選択確定後に移動）。"
       ],
       "zoom": [
         "orientation=\"top|bottom|left|right\" でレイアウトを切り替えます。",
@@ -3339,7 +3341,7 @@
         "id": "active-tab",
         "title": "選択中タブ",
         "label": "role=\"tab\"",
-        "description": "現在選択されているタブです。aria-selected=\"true\" と roving tabindex の起点を持ちます。",
+        "description": "現在選択されているタブです。aria-selected=\"true\" を持ち、対応パネルは aria-controls で関連付けられます。",
         "category": "states",
         "placement": "top-right",
         "target": {
@@ -3353,7 +3355,7 @@
         "label": "part=\"indicator\"",
         "description": "選択中タブを示す視覚インジケーターです。",
         "category": "states",
-        "placement": "top-right",
+        "placement": "bottom-left",
         "target": {
           "scope": "shadow",
           "selector": "[part=\"tab\"][aria-selected=\"true\"] [part=\"indicator\"]"
@@ -3377,7 +3379,7 @@
         "label": "role=\"tabpanel\"",
         "description": "選択中タブに対応するパネルコンテンツです。",
         "category": "semantics",
-        "placement": "bottom-left",
+        "placement": "bottom-right",
         "target": {
           "scope": "light",
           "selector": "[role=\"tabpanel\"]:not([hidden])"

--- a/docs/llms/tab.md
+++ b/docs/llms/tab.md
@@ -65,6 +65,7 @@ npx wcf vendor install --prefix myui --dir vendor/components/myui --component ta
 | `--dads-tab-indicator-height` | - | インジケーター高さ |
 | `--dads-tab-focus-outline-color` | - | フォーカスアウトライン色 |
 | `--dads-tab-focus-ring-color` | - | フォーカスリング色 |
+| `--dads-tab-focus-border-radius` | - | フォーカスリングの角丸 |
 
 
 ## Events

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4460,6 +4460,7 @@ None
 | `--dads-tab-indicator-height` | - | インジケーター高さ |
 | `--dads-tab-focus-outline-color` | - | フォーカスアウトライン色 |
 | `--dads-tab-focus-ring-color` | - | フォーカスリング色 |
+| `--dads-tab-focus-border-radius` | - | フォーカスリングの角丸 |
 
 
 #### Events

--- a/packages/components/tab/tab-styles.ts
+++ b/packages/components/tab/tab-styles.ts
@@ -81,6 +81,7 @@ export const tabStyles = css`
 
   [part~="tab"]:focus-visible {
     z-index: 3;
+    border-radius: var(--dads-tab-focus-border-radius);
   }
 
   /* DADSフォーカスリングは維持しつつ、タブ面は塗りつぶさない */
@@ -149,9 +150,6 @@ export const tabStyles = css`
     [part~="tab"]:not([aria-selected="true"]):not([aria-disabled="true"]):hover {
       --_dads-tab-background: var(--dads-tab-background-hover);
       --_dads-tab-label-decoration: underline;
-    }
-
-    [part~="tab"]:not([aria-selected="true"]):not([aria-disabled="true"]):hover {
       --_dads-tab-indicator-color: var(--dads-tab-border-color);
     }
   }
@@ -169,6 +167,13 @@ export const tabStyles = css`
 
   ::slotted([part~="tabpanel"][hidden]) {
     display: none;
+  }
+
+  ::slotted([part~="tabpanel"]:focus-visible) {
+    outline: var(--dads-focus-outline-width) solid var(--dads-focus-outline-color);
+    outline-offset: var(--dads-focus-outline-offset);
+    box-shadow: 0 0 0 var(--dads-focus-ring-width) var(--dads-focus-ring-color);
+    border-radius: var(--dads-tab-focus-border-radius);
   }
 
   :host([orientation="bottom"]) [part="base"] {

--- a/packages/components/tab/tab-tokens.ts
+++ b/packages/components/tab/tab-tokens.ts
@@ -25,6 +25,7 @@ const tabSemanticTokensText = `
     /* Focus */
     --tab-focus-outline-color: var(--color-neutral-black, #000000);
     --tab-focus-ring-color: var(--color-primitive-yellow-300, #ffd43d);
+    --tab-focus-border-radius: calc(4 / 16 * 1rem);
 
     /* ========== Layout ========== */
     --tab-indicator-thickness: calc(6 / 16 * 1rem);
@@ -60,6 +61,7 @@ const tabLocalTokensText = `
     --dads-tab-indicator-height: var(--tab-indicator-thickness);
     --dads-tab-focus-outline-color: var(--tab-focus-outline-color);
     --dads-tab-focus-ring-color: var(--tab-focus-ring-color);
+    --dads-tab-focus-border-radius: var(--tab-focus-border-radius);
   }
 `;
 

--- a/packages/components/tab/tab.test.ts
+++ b/packages/components/tab/tab.test.ts
@@ -296,13 +296,13 @@ describe('DadsTab', () => {
       expect(eventDetail!.previousIndex).toBe(0);
     });
 
-    it('tabpanel に tabindex="0" が設定される', async () => {
+    it('tabpanel に tabindex="-1" が設定される（Tab 順序から除外）', async () => {
       const tab = createBasicTab();
       await waitForComponent('dads-tab');
 
       const panels = getPanels(tab);
       for (const p of panels) {
-        expect(p.getAttribute('tabindex')).toBe('0');
+        expect(p.getAttribute('tabindex')).toBe('-1');
       }
     });
 
@@ -324,27 +324,27 @@ describe('DadsTab', () => {
   // ============================================================
   // Step 3: キーボードモデルと roving tabindex (P-03) — C-03, C-04, C-06
   // ============================================================
-  describe('Roving tabindex (Step 3, C-03)', () => {
-    it('選択タブのみ tabindex="0"、他は "-1"', async () => {
+  describe('Tab キーモデル (Step 3, C-03)', () => {
+    it('全タブが tabindex="0" で Tab 巡回可能', async () => {
       const tab = createBasicTab();
       await waitForComponent('dads-tab');
 
       const tabs = getTabs(tab);
       expect(tabs[0].getAttribute('tabindex')).toBe('0');
-      expect(tabs[1].getAttribute('tabindex')).toBe('-1');
-      expect(tabs[2].getAttribute('tabindex')).toBe('-1');
+      expect(tabs[1].getAttribute('tabindex')).toBe('0');
+      expect(tabs[2].getAttribute('tabindex')).toBe('0');
     });
 
-    it('selected-index 変更後も tabindex が1つだけ "0"', async () => {
+    it('selected-index 変更後も全タブ tabindex="0"', async () => {
       const tab = createBasicTab();
       await waitForComponent('dads-tab');
 
       tab.setAttribute('selected-index', '1');
 
       const tabs = getTabs(tab);
-      expect(tabs[0].getAttribute('tabindex')).toBe('-1');
+      expect(tabs[0].getAttribute('tabindex')).toBe('0');
       expect(tabs[1].getAttribute('tabindex')).toBe('0');
-      expect(tabs[2].getAttribute('tabindex')).toBe('-1');
+      expect(tabs[2].getAttribute('tabindex')).toBe('0');
     });
   });
 
@@ -476,7 +476,7 @@ describe('DadsTab', () => {
   });
 
   describe('auto/manual モード (Step 3, C-04)', () => {
-    it('auto モード: Enter は panel へフォーカス移動しない', async () => {
+    it('auto モード: Enter で tabpanel へフォーカス移動する', async () => {
       const tab = createBasicTab();
       await waitForComponent('dads-tab');
 
@@ -487,8 +487,8 @@ describe('DadsTab', () => {
       pressKey(tabs[0], 'Enter');
 
       expect(tab.getAttribute('selected-index')).toBe('0');
-      expect(document.activeElement === tabs[0] || tabs[0].matches(':focus')).toBe(true);
       expect(panels[0].hasAttribute('hidden')).toBe(false);
+      expect(document.activeElement === panels[0] || panels[0].matches(':focus')).toBe(true);
     });
 
     it('auto モード: Arrow でフォーカスと選択が同時に変更される', async () => {
@@ -516,7 +516,7 @@ describe('DadsTab', () => {
       expect(tab.getAttribute('selected-index')).toBe('0');
     });
 
-    it('manual モード: Enter で選択変更される', async () => {
+    it('manual モード: Enter で選択変更 + tabpanel へフォーカス移動', async () => {
       const tab = createBasicTab();
       await waitForComponent('dads-tab');
 
@@ -530,11 +530,12 @@ describe('DadsTab', () => {
       // tabs[1] で Enter を押す
       pressKey(tabs[1], 'Enter');
 
+      const panels = getPanels(tab);
       expect(tab.getAttribute('selected-index')).toBe('1');
-      expect(document.activeElement === tabs[1] || tabs[1].matches(':focus')).toBe(true);
+      expect(document.activeElement === panels[1] || panels[1].matches(':focus')).toBe(true);
     });
 
-    it('manual モード: Space で選択変更される', async () => {
+    it('manual モード: Space で選択変更（フォーカスはタブに留まる）', async () => {
       const tab = createBasicTab();
       await waitForComponent('dads-tab');
 
@@ -546,6 +547,7 @@ describe('DadsTab', () => {
       pressKey(tabs[1], ' ');
 
       expect(tab.getAttribute('selected-index')).toBe('1');
+      expect(document.activeElement === tabs[1] || tabs[1].matches(':focus')).toBe(true);
     });
   });
 

--- a/packages/components/tab/tab.ts
+++ b/packages/components/tab/tab.ts
@@ -23,6 +23,15 @@ import { tabStyles } from './tab-styles.js';
 type TabOrientation = 'top' | 'bottom' | 'left' | 'right';
 type ActivationMode = 'auto' | 'manual';
 
+const navigationKeys: ReadonlySet<string> = new Set([
+  Keys.arrowUp,
+  Keys.arrowDown,
+  Keys.arrowLeft,
+  Keys.arrowRight,
+  Keys.home,
+  Keys.end,
+]);
+
 function normalizeOrientation(v: string | null): TabOrientation {
   if (v === 'bottom' || v === 'left' || v === 'right') return v;
   return 'top';
@@ -68,6 +77,7 @@ function isHorizontalOrientation(orientation: TabOrientation): boolean {
  * @cssprop --dads-tab-indicator-height - インジケーター高さ
  * @cssprop --dads-tab-focus-outline-color - フォーカスアウトライン色
  * @cssprop --dads-tab-focus-ring-color - フォーカスリング色
+ * @cssprop --dads-tab-focus-border-radius - フォーカスリングの角丸
  *
  * @fires dads-tab-change - タブ選択変更時（detail: { selectedIndex: number, previousIndex: number }）
  *
@@ -246,6 +256,10 @@ export class DadsTab extends TypographyWebComponent {
     return children;
   }
 
+  #getSelectedIndex(): number {
+    return Math.max(0, parseInt(this.getAttribute('selected-index') ?? '0', 10) || 0);
+  }
+
   #syncTabs(): void {
     const tablist = this.#tablist;
     if (!tablist) return;
@@ -277,6 +291,7 @@ export class DadsTab extends TypographyWebComponent {
       tab.setAttribute('role', 'tab');
       tab.setAttribute('id', tabId);
       tab.setAttribute('aria-controls', child.id);
+      tab.setAttribute('tabindex', '0');
       tab.type = 'button';
       tab.addEventListener('click', this.#handleTabClick);
       tab.addEventListener('keydown', this.#handleKeyDown);
@@ -299,7 +314,7 @@ export class DadsTab extends TypographyWebComponent {
       child.setAttribute('role', 'tabpanel');
       child.setAttribute('part', 'tabpanel');
       child.setAttribute('aria-labelledby', tabId);
-      child.setAttribute('tabindex', '0');
+      child.setAttribute('tabindex', '-1');
 
       tablist.appendChild(tab);
       this.#tabs.push(tab);
@@ -343,21 +358,17 @@ export class DadsTab extends TypographyWebComponent {
   }
 
   #syncSelection(): void {
-    const index = Math.max(0, parseInt(this.getAttribute('selected-index') ?? '0', 10) || 0);
-    const clampedIndex = Math.min(index, this.#tabs.length - 1);
+    const clampedIndex = Math.min(this.#getSelectedIndex(), this.#tabs.length - 1);
 
     for (let i = 0; i < this.#tabs.length; i++) {
-      const tab = this.#tabs[i];
-      const panel = this.#panels[i];
       const isSelected = i === clampedIndex;
 
-      tab.setAttribute('aria-selected', String(isSelected));
-      tab.setAttribute('tabindex', isSelected ? '0' : '-1');
+      this.#tabs[i].setAttribute('aria-selected', String(isSelected));
 
       if (isSelected) {
-        panel.removeAttribute('hidden');
+        this.#panels[i].removeAttribute('hidden');
       } else {
-        panel.setAttribute('hidden', '');
+        this.#panels[i].setAttribute('hidden', '');
       }
     }
   }
@@ -383,17 +394,9 @@ export class DadsTab extends TypographyWebComponent {
 
   #handleKeyDown = (event: KeyboardEvent): void => {
     const currentTab = event.currentTarget as HTMLButtonElement;
-    if (
-      currentTab.getAttribute('aria-disabled') === 'true' &&
-      event.key !== Keys.arrowUp &&
-      event.key !== Keys.arrowDown &&
-      event.key !== Keys.arrowLeft &&
-      event.key !== Keys.arrowRight &&
-      event.key !== Keys.home &&
-      event.key !== Keys.end
-    ) {
-      return;
-    }
+    const isDisabled = currentTab.getAttribute('aria-disabled') === 'true';
+
+    if (isDisabled && !navigationKeys.has(event.key)) return;
 
     const mode = normalizeActivationMode(this.getAttribute('activation-mode'));
     const orientation = normalizeOrientation(this.getAttribute('orientation'));
@@ -401,13 +404,20 @@ export class DadsTab extends TypographyWebComponent {
       ? Orientation.horizontal
       : Orientation.vertical;
 
-    // APG: manual モードでは Enter/Space で選択確定。フォーカスは tab に留める。
-    if (mode === 'manual' && (event.key === Keys.enter || event.key === Keys.space)) {
+    // Enter: タブパネルへフォーカスを移す（manual モードでは先に選択確定）
+    if (event.key === Keys.enter) {
       event.preventDefault();
-      const index = this.#tabs.indexOf(currentTab);
-      if (index >= 0 && currentTab.getAttribute('aria-disabled') !== 'true') {
-        this.#selectTab(index);
+      if (mode === 'manual') {
+        this.#activateTab(currentTab);
       }
+      this.#focusActivePanel();
+      return;
+    }
+
+    // Space: manual モードでは選択確定（フォーカスはタブに留まる）
+    if (mode === 'manual' && event.key === Keys.space) {
+      event.preventDefault();
+      this.#activateTab(currentTab);
       return;
     }
 
@@ -420,10 +430,7 @@ export class DadsTab extends TypographyWebComponent {
       (target) => {
         target.focus();
         if (mode === 'auto') {
-          const index = this.#tabs.indexOf(target);
-          if (index >= 0) {
-            this.#selectTab(index);
-          }
+          this.#activateTab(target);
         }
       },
       {
@@ -434,8 +441,23 @@ export class DadsTab extends TypographyWebComponent {
     );
   };
 
+  #focusActivePanel(): void {
+    const clampedIndex = Math.min(this.#getSelectedIndex(), this.#panels.length - 1);
+    if (clampedIndex >= 0 && this.#panels[clampedIndex]) {
+      this.#panels[clampedIndex].focus();
+    }
+  }
+
+  #activateTab(tab: HTMLButtonElement): void {
+    if (tab.getAttribute('aria-disabled') === 'true') return;
+    const index = this.#tabs.indexOf(tab);
+    if (index >= 0) {
+      this.#selectTab(index);
+    }
+  }
+
   #selectTab(index: number): void {
-    const previousIndex = parseInt(this.getAttribute('selected-index') ?? '0', 10) || 0;
+    const previousIndex = this.#getSelectedIndex();
     if (index === previousIndex) return;
 
     this.setAttribute('selected-index', String(index));


### PR DESCRIPTION
# fix(tab): keep keyboard model and focus ring radius

## Summary
- What changed:
  - タブのキーボードモデルを「全タブ `tabindex="0"`（Tab 巡回可能）」として固定し、Enter で選択中 tabpanel へフォーカス移動（manual は Enter/Space で選択確定）。
  - tabpanel を Tab 順序から除外（`tabindex="-1"`）しつつ、プログラム的なフォーカス移動は可能に。
  - focus ring の角丸を `--dads-tab-focus-border-radius` としてトークン化し、tab / tabpanel の `:focus-visible` を同じ角丸に統一。
  - a11y 注釈（`docs/knowledge/a11y-annotations.json`）と CEM/LLM docs（`custom-elements.json` / `docs/llms/tab.md` / `llms-full.txt`）を同期。
- Why this change is needed:
  - 現行キーボードモデル（Tab 巡回）を前提に、実装/テスト/ドキュメントのズレを解消し、focus ring の見た目を一貫させるため。

## Scope
- In scope:
  - `packages/components/tab/**`（keyboard, tabindex, focus, tokens/styles, tests）
  - `docs/knowledge/a11y-annotations.json` + generated docs（`custom-elements.json`, `docs/llms/tab.md`, `llms-full.txt`）
  - knowledge log
- Out of scope:
  - APG roving tabindex への回帰
  - デザイン/レイアウトの大規模変更

## Quality Gate Results
- Gate Summary: PASS（`npm run agents:verify`）
- Accessibility Findings:
  - role/aria: tab ↔ tabpanel を `aria-controls` / `aria-labelledby` で関連付け
  - keyboard: Tab で tab にフォーカス、Arrow/Home/End で移動、auto/manual、Enter で tabpanel focus、Space(manual)で選択確定
  - focus-visible: `--dads-focus-*` を使用し、tabpanel も `:focus-visible` を提供
- Coverage Delta (base vs HEAD):
  - lines: 88.02 → 88.02 (0.00pp)
  - statements: 83.19 → 83.19 (0.00pp)
  - functions: 86.29 → 86.30 (+0.01pp)
  - branches: 69.96 → 69.96 (0.00pp)
- Code Simplification Summary:
  - `#getSelectedIndex()` / `#activateTab()` で重複処理を集約
  - navigation key 判定を `Set` に集約

## Applied Fixes
- `packages/components/tab/tab.ts`: keyboard handling + focus behavior + tabindex rules
- `packages/components/tab/tab-styles.ts`: tab + tabpanel の `:focus-visible` 角丸/リング整合
- `packages/components/tab/tab-tokens.ts`: `--dads-tab-focus-border-radius` を追加
- `packages/components/tab/tab.test.ts`: 仕様に合わせてテスト更新
- `docs/knowledge/a11y-annotations.json`: キーボードモデル説明を現行挙動に合わせて更新
- Generated: `custom-elements.json`, `docs/llms/tab.md`, `llms-full.txt`

## Proposed Fixes (Not Applied)
- (none)

## Knowledge Update
- Path: `docs/knowledge/2026-02-25-tab-keyboard-model-focus-ring-postflight.md`
- What was documented:
  - キーボードモデル変更時の docs/CEM/LLM 同期ルール
  - focus ring のトークン運用ルール

## Validation
- Commands run:
  - base/head coverage: `npm run test:run -- --coverage --coverage.reporter=json-summary`
  - `npm run agents:verify`
- Results: PASS

## Risks
- Risk: Tab でタブを巡回できるモデルは APG の roving tabindex と異なるため、利用者の期待とズレる可能性。
- Mitigation: a11y 注釈と LLM docs を更新し、挙動はテストで固定。
