### PR TITLE
chore(mcp-server): bump @monoharada/wcf-mcp to 0.1.2

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monoharada/wcf-mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "MCP server for the web-components-factory design system. Provides component discovery, validation, and pattern-based UI composition without cloning the repository.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- bump `@monoharada/wcf-mcp` package version from `0.1.1` to `0.1.2`

## Scope
- `packages/mcp-server/package.json` only

## Verification
- `npm pack --dry-run` (in `packages/mcp-server`)
  - package: `@monoharada/wcf-mcp@0.1.2`
  - tarball: `monoharada-wcf-mcp-0.1.2.tgz`
