### PR TITLE
chore(vendor-runtime): sync generated runtime and component docs

### DIFF
--- a/docs/components/loading-icon.md
+++ b/docs/components/loading-icon.md
@@ -1,0 +1,18 @@
+<!-- GENERATED:WCF_COMPONENT_DOC -->
+
+# loading-icon
+
+- tag base: `loading-icon`
+- define module: `src/components/loading-icon/index.js`
+- define function: `defineDefaultLoadingIcon`
+- vendor entry: `components/loading-icon.js`
+
+## 使われるBlocks
+
+- (none)
+
+## 導入コマンド
+
+```bash
+node scripts/wcf/cli.js vendor install --prefix myui --dir vendor/components/myui --component loading-icon
+```

--- a/docs/components/progress-bar.md
+++ b/docs/components/progress-bar.md
@@ -1,0 +1,18 @@
+<!-- GENERATED:WCF_COMPONENT_DOC -->
+
+# progress-bar
+
+- tag base: `progress-bar`
+- define module: `src/components/progress-bar/index.js`
+- define function: `defineDefaultProgressBar`
+- vendor entry: `components/progress-bar.js`
+
+## 使われるBlocks
+
+- (none)
+
+## 導入コマンド
+
+```bash
+node scripts/wcf/cli.js vendor install --prefix myui --dir vendor/components/myui --component progress-bar
+```

--- a/docs/components/spinner.md
+++ b/docs/components/spinner.md
@@ -1,0 +1,18 @@
+<!-- GENERATED:WCF_COMPONENT_DOC -->
+
+# spinner
+
+- tag base: `spinner`
+- define module: `src/components/spinner/index.js`
+- define function: `defineDefaultSpinner`
+- vendor entry: `components/spinner.js`
+
+## 使われるBlocks
+
+- (none)
+
+## 導入コマンド
+
+```bash
+node scripts/wcf/cli.js vendor install --prefix myui --dir vendor/components/myui --component spinner
+```

--- a/docs/components/tab.md
+++ b/docs/components/tab.md
@@ -1,0 +1,18 @@
+<!-- GENERATED:WCF_COMPONENT_DOC -->
+
+# tab
+
+- tag base: `tab`
+- define module: `src/components/tab/index.js`
+- define function: `defineTab`
+- vendor entry: `components/tab.js`
+
+## 使われるBlocks
+
+- (none)
+
+## 導入コマンド
+
+```bash
+node scripts/wcf/cli.js vendor install --prefix myui --dir vendor/components/myui --component tab
+```

--- a/vendor-runtime/src/components/button/button-styles.js
+++ b/vendor-runtime/src/components/button/button-styles.js
@@ -13,6 +13,10 @@ export const buttonStyles = css `
     max-width: var(--dads-button-max-width, none);
   }
 
+  :host(:focus-visible) {
+    outline: none;
+  }
+
   :host([full-width]) {
     display: block;
     width: 100%;
@@ -62,7 +66,7 @@ export const buttonStyles = css `
   }
 
   /* フォーカススタイルはmixin (applyFocusStyles) で適用 */
-  
+
   /* Disabled時のフォーカススタイル（button要素のみ） */
   :host([disabled]) button[part="base"]:focus,
   button[part="base"]:disabled:focus {

--- a/vendor-runtime/src/components/button/button.js
+++ b/vendor-runtime/src/components/button/button.js
@@ -140,6 +140,20 @@ export class DadsButton extends TypographyFormComponent {
         this.removeEventListener('click', __classPrivateFieldGet(this, _DadsButton_handleHostClick, "f"));
         __classPrivateFieldGet(this, _DadsButton_instances, "m", _DadsButton_teardownIconSlots).call(this);
     }
+    focus(options) {
+        const base = this.shadowRoot?.querySelector('[part="base"]');
+        if (base)
+            base.focus(options);
+        else
+            super.focus(options);
+    }
+    blur() {
+        const base = this.shadowRoot?.querySelector('[part="base"]');
+        if (base)
+            base.blur();
+        else
+            super.blur();
+    }
     attributeChangedCallback(name, oldValue, newValue) {
         super.attributeChangedCallback(name, oldValue, newValue);
         // as属性やhref属性が変更された場合は再レンダリングが必要
@@ -376,6 +390,7 @@ _DadsButton_iconStartSlot = new WeakMap(), _DadsButton_iconEndSlot = new WeakMap
 DadsButton.formAssociated = true;
 DadsButton.definition = {
     name: 'dads-button',
+    shadowOptions: { mode: 'open', delegatesFocus: true },
     template: html `
       <button 
         part="base"

--- a/vendor-runtime/src/components/loading-icon/loading-icon-styles.js
+++ b/vendor-runtime/src/components/loading-icon/loading-icon-styles.js
@@ -34,7 +34,6 @@ export const loadingIconStyles = css `
   :host([underlay]) [part="base"] {
     min-width: 128px;
     min-height: 128px;
-    padding: var(--spacing-4);
     justify-content: center;
     box-sizing: border-box;
   }
@@ -43,7 +42,7 @@ export const loadingIconStyles = css `
     display: block;
     position: absolute;
     inset: 0;
-    border-radius: 12px;
+    border-radius: var(--spacing-3);
     border: 1px solid var(--dads-loading-icon-underlay-border);
     background: var(--dads-loading-icon-underlay-bg);
     z-index: -1;
@@ -70,7 +69,8 @@ export const loadingIconStyles = css `
     color: var(--dads-loading-icon-label-color);
   }
 
-  :host(:not([label])) [part="label"] {
+  :host(:not([label])) [part="label"],
+  :host([label=""]) [part="label"] {
     display: none;
   }
 
@@ -81,6 +81,7 @@ export const loadingIconStyles = css `
 
     [part="underlay"] {
       border-color: CanvasText;
+      background: Canvas;
     }
   }
 `;

--- a/vendor-runtime/src/components/loading-icon/loading-icon.js
+++ b/vendor-runtime/src/components/loading-icon/loading-icon.js
@@ -114,7 +114,11 @@ DadsLoadingIcon.definition = {
       <div part="base">
         <div part="underlay" aria-hidden="true"></div>
         <svg part="icon" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-          <path d="M14 4v4.01c0 2.12.84 4.16 2.34 5.66L22 19.33c1.1 1.1 1.1 2.9 0 4l-5.66 5.66A7.986 7.986 0 0014 34.65V40h20v-5.35c0-2.12-.84-4.16-2.34-5.66L26 23.33c-1.1-1.1-1.1-2.9 0-4l5.66-5.66A7.986 7.986 0 0034 8.01V4H14zm16 30.65V38H18v-3.35c0-1.59.63-3.12 1.76-4.24L24 26.17l4.24 4.24A5.993 5.993 0 0130 34.65zM30 8.01a5.993 5.993 0 01-1.76 4.24L24 16.49l-4.24-4.24A5.993 5.993 0 0118 8.01V6h12v2.01z" fill="currentColor"/>
+          <path d="M24 24C34.5 24 35.5 6 35.5 4.78V4M24 24C13.5 24 12.5 6 12.5 4.78V4M24 24C31 24 35.5 35.79 35.5 42.26V44M24 24C17 24 12.5 35.79 12.5 42.26V44M9 4H39M9 44H39" fill="none" stroke="currentColor" stroke-width="2"/>
+          <path d="M17 15C17 17.5 19.241 22 24 22C28.759 22 31 17 31 15H17Z" fill="currentColor"/>
+          <path d="M15 42C16.895 42 31.579 42 33 42C33 40.001 32 37.5 32 37.5L24 34L16 37.5C16 37.5 15 40.001 15 42Z" fill="currentColor"/>
+          <circle cx="24" cy="28" r="1" fill="currentColor"/>
+          <circle cx="24" cy="31" r="1" fill="currentColor"/>
         </svg>
         <span part="label"></span>
       </div>

--- a/vendor-runtime/src/components/progress-bar/progress-bar-styles.js
+++ b/vendor-runtime/src/components/progress-bar/progress-bar-styles.js
@@ -24,7 +24,7 @@ export const progressBarStyles = css `
   }
 
   :host([composition="inlined"]) [part="label"] {
-    min-width: 0;
+    flex-shrink: 0;
     white-space: nowrap;
   }
 
@@ -33,9 +33,7 @@ export const progressBarStyles = css `
   }
 
   :host([underlay]) [part="base"] {
-    min-width: 128px;
-    min-height: 128px;
-    padding: var(--spacing-4);
+    padding: var(--spacing-6);
     justify-content: center;
     box-sizing: border-box;
   }
@@ -44,7 +42,7 @@ export const progressBarStyles = css `
     display: block;
     position: absolute;
     inset: 0;
-    border-radius: 12px;
+    border-radius: var(--spacing-3);
     border: 1px solid var(--dads-progress-bar-underlay-border);
     background: var(--dads-progress-bar-underlay-bg);
     z-index: -1;
@@ -55,9 +53,8 @@ export const progressBarStyles = css `
     height: 4px;
     position: relative;
     overflow: hidden;
-    border-radius: 2px;
     background: var(--dads-progress-bar-track-color);
-    border-bottom: 1px solid var(--dads-progress-bar-track-color);
+    border-bottom: 1px solid var(--dads-progress-bar-indicator-color);
   }
 
   [part="indicator"] {
@@ -69,10 +66,6 @@ export const progressBarStyles = css `
     transition: transform 0.3s ease;
   }
 
-  :host(:not([data-determinate])) [part="indicator"] {
-    animation: linear-indeterminate 2s ease-in-out infinite;
-  }
-
   [part="label"] {
     font-family: var(--font-family-sans);
     font-size: var(--font-size-16, 1rem);
@@ -82,30 +75,14 @@ export const progressBarStyles = css `
     color: var(--dads-progress-bar-label-color);
   }
 
-  :host(:not([label])) [part="label"] {
+  :host(:not([label])) [part="label"],
+  :host([label=""]) [part="label"] {
     display: none;
-  }
-
-  @keyframes linear-indeterminate {
-    0% {
-      transform: translateX(-100%) scaleX(0.4);
-    }
-    50% {
-      transform: translateX(0%) scaleX(0.6);
-    }
-    100% {
-      transform: translateX(100%) scaleX(0.4);
-    }
   }
 
   @media (prefers-reduced-motion: reduce) {
     [part="indicator"] {
       transition: none;
-    }
-
-    :host(:not([data-determinate])) [part="indicator"] {
-      animation: none;
-      transform: translateX(0) scaleX(0.6);
     }
   }
 
@@ -120,6 +97,7 @@ export const progressBarStyles = css `
 
     [part="underlay"] {
       border-color: CanvasText;
+      background: Canvas;
     }
   }
 `;

--- a/vendor-runtime/src/components/progress-bar/progress-bar.js
+++ b/vendor-runtime/src/components/progress-bar/progress-bar.js
@@ -14,7 +14,7 @@ var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (
     if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
     return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
 };
-var _DadsProgressBar_instances, _DadsProgressBar_base, _DadsProgressBar_indicator, _DadsProgressBar_labelEl, _DadsProgressBar_setDefaultAttributes, _DadsProgressBar_syncProgress, _DadsProgressBar_syncLabel;
+var _DadsProgressBar_instances, _DadsProgressBar_base, _DadsProgressBar_indicator, _DadsProgressBar_labelEl, _DadsProgressBar_setDefaultAttributes, _DadsProgressBar_syncProgress, _DadsProgressBar_syncValueText, _DadsProgressBar_syncLabel;
 import { html, PropertyAttr, BooleanAttr, } from '../../core/web-components.js';
 import { TypographyWebComponent } from '../../core/typography/typography-web-component.js';
 import { applyDADSTokens } from '../../styles/design-tokens/index.js';
@@ -26,7 +26,7 @@ import { progressBarStyles } from './progress-bar-styles.js';
  * Progress Barコンポーネント
  *
  * 水平バーで進捗状況を表示する。
- * value属性の有無でdeterminate/indeterminateモードを自動切替する。
+ * 常にdeterminate（確定値）モードで動作する。不確定状態にはSpinnerを使用する。
  *
  * @customElement
  * @tagname dads-progress-bar
@@ -37,11 +37,12 @@ import { progressBarStyles } from './progress-bar-styles.js';
  * @csspart indicator - インジケーターバー（進捗表示）
  * @csspart label - ラベルテキスト
  *
- * @attr {string} value - 進捗値（0〜max、未設定=indeterminate）
+ * @attr {string} value - 進捗値（0〜max）
  * @attr {string} max - 最大値（デフォルト: 1、0以下は1にクランプ）
  * @attr {'stacked' | 'inlined'} composition - レイアウト方向
  * @attr {boolean} underlay - カード背景表示
  * @attr {string} label - 表示ラベル兼アクセシブル名
+ * @attr {string} value-text - 人間可読な進捗テキスト（aria-valuetextに反映）
  *
  * @cssprop --dads-progress-bar-track-color - トラック色
  * @cssprop --dads-progress-bar-indicator-color - インジケーター色
@@ -53,7 +54,7 @@ import { progressBarStyles } from './progress-bar-styles.js';
  * ```html
  * <dads-progress-bar value="0.5" label="50%"></dads-progress-bar>
  * <dads-progress-bar value="3" max="10" label="30%"></dads-progress-bar>
- * <dads-progress-bar label="読み込み中"></dads-progress-bar>
+ * <!-- 不確定状態には dads-spinner を使用 -->
  * <dads-progress-bar underlay value="0.7" label="70%"></dads-progress-bar>
  * ```
  */
@@ -73,6 +74,7 @@ export class DadsProgressBar extends TypographyWebComponent {
         __classPrivateFieldGet(this, _DadsProgressBar_instances, "m", _DadsProgressBar_setDefaultAttributes).call(this);
         __classPrivateFieldGet(this, _DadsProgressBar_instances, "m", _DadsProgressBar_syncProgress).call(this);
         __classPrivateFieldGet(this, _DadsProgressBar_instances, "m", _DadsProgressBar_syncLabel).call(this);
+        __classPrivateFieldGet(this, _DadsProgressBar_instances, "m", _DadsProgressBar_syncValueText).call(this);
     }
     valueChanged() {
         __classPrivateFieldGet(this, _DadsProgressBar_instances, "m", _DadsProgressBar_syncProgress).call(this);
@@ -83,6 +85,9 @@ export class DadsProgressBar extends TypographyWebComponent {
     labelChanged() {
         __classPrivateFieldGet(this, _DadsProgressBar_instances, "m", _DadsProgressBar_syncLabel).call(this);
     }
+    valueTextChanged() {
+        __classPrivateFieldGet(this, _DadsProgressBar_instances, "m", _DadsProgressBar_syncValueText).call(this);
+    }
 }
 _DadsProgressBar_base = new WeakMap(), _DadsProgressBar_indicator = new WeakMap(), _DadsProgressBar_labelEl = new WeakMap(), _DadsProgressBar_instances = new WeakSet(), _DadsProgressBar_setDefaultAttributes = function _DadsProgressBar_setDefaultAttributes() {
     if (!this.hasAttribute('composition')) {
@@ -92,27 +97,27 @@ _DadsProgressBar_base = new WeakMap(), _DadsProgressBar_indicator = new WeakMap(
     if (!__classPrivateFieldGet(this, _DadsProgressBar_base, "f") || !__classPrivateFieldGet(this, _DadsProgressBar_indicator, "f"))
         return;
     const rawValue = this.getAttribute('value');
-    const parsedValue = rawValue !== null ? Number(rawValue) : Number.NaN;
-    const isDeterminate = rawValue !== null && !Number.isNaN(parsedValue);
-    if (isDeterminate) {
-        const rawMax = this.getAttribute('max');
-        const parsedMax = rawMax !== null ? Number(rawMax) : 1;
-        const effectiveMax = parsedMax > 0 ? parsedMax : 1;
-        const clamped = Math.min(Math.max(0, parsedValue), effectiveMax);
-        const normalized = clamped / effectiveMax;
-        const ariaValue = Math.round(normalized * 100);
-        __classPrivateFieldGet(this, _DadsProgressBar_indicator, "f").style.setProperty('--progress', String(normalized));
-        __classPrivateFieldGet(this, _DadsProgressBar_base, "f").setAttribute('aria-valuenow', String(ariaValue));
-        __classPrivateFieldGet(this, _DadsProgressBar_base, "f").setAttribute('aria-valuemin', '0');
-        __classPrivateFieldGet(this, _DadsProgressBar_base, "f").setAttribute('aria-valuemax', '100');
-        this.setAttribute('data-determinate', '');
+    const parsedValue = rawValue !== null ? Number(rawValue) : 0;
+    const effectiveValue = Number.isNaN(parsedValue) ? 0 : parsedValue;
+    const rawMax = this.getAttribute('max');
+    const parsedMax = rawMax !== null ? Number(rawMax) : 1;
+    const effectiveMax = parsedMax > 0 ? parsedMax : 1;
+    const clamped = Math.min(Math.max(0, effectiveValue), effectiveMax);
+    const normalized = clamped / effectiveMax;
+    const ariaValue = Math.round(normalized * 100);
+    __classPrivateFieldGet(this, _DadsProgressBar_indicator, "f").style.setProperty('--progress', String(normalized));
+    __classPrivateFieldGet(this, _DadsProgressBar_base, "f").setAttribute('aria-valuenow', String(ariaValue));
+    __classPrivateFieldGet(this, _DadsProgressBar_base, "f").setAttribute('aria-valuemin', '0');
+    __classPrivateFieldGet(this, _DadsProgressBar_base, "f").setAttribute('aria-valuemax', '100');
+}, _DadsProgressBar_syncValueText = function _DadsProgressBar_syncValueText() {
+    if (!__classPrivateFieldGet(this, _DadsProgressBar_base, "f"))
+        return;
+    const valueText = this.getAttribute('value-text');
+    if (valueText && valueText.length > 0) {
+        __classPrivateFieldGet(this, _DadsProgressBar_base, "f").setAttribute('aria-valuetext', valueText);
     }
     else {
-        __classPrivateFieldGet(this, _DadsProgressBar_indicator, "f").style.removeProperty('--progress');
-        __classPrivateFieldGet(this, _DadsProgressBar_base, "f").removeAttribute('aria-valuenow');
-        __classPrivateFieldGet(this, _DadsProgressBar_base, "f").removeAttribute('aria-valuemin');
-        __classPrivateFieldGet(this, _DadsProgressBar_base, "f").removeAttribute('aria-valuemax');
-        this.removeAttribute('data-determinate');
+        __classPrivateFieldGet(this, _DadsProgressBar_base, "f").removeAttribute('aria-valuetext');
     }
 }, _DadsProgressBar_syncLabel = function _DadsProgressBar_syncLabel() {
     if (!__classPrivateFieldGet(this, _DadsProgressBar_base, "f") || !__classPrivateFieldGet(this, _DadsProgressBar_labelEl, "f"))
@@ -151,5 +156,6 @@ DadsProgressBar.definition = {
         PropertyAttr('composition'),
         BooleanAttr('underlay'),
         PropertyAttr('label'),
+        PropertyAttr('valueText', 'value-text'),
     ],
 };

--- a/vendor-runtime/src/components/spinner/spinner-styles.js
+++ b/vendor-runtime/src/components/spinner/spinner-styles.js
@@ -43,7 +43,7 @@ export const spinnerStyles = css `
     display: block;
     position: absolute;
     inset: 0;
-    border-radius: 12px;
+    border-radius: var(--spacing-3);
     border: 1px solid var(--dads-spinner-underlay-border);
     background: var(--dads-spinner-underlay-bg);
     z-index: -1;
@@ -53,7 +53,7 @@ export const spinnerStyles = css `
     display: block;
     width: 48px;
     height: 48px;
-    animation: spinner-rotate 2s linear infinite;
+    animation: spinner-rotate var(--dads-spinner-rotate-duration) linear infinite;
   }
 
   :host([size="sm"]) [part="svg"] {
@@ -62,14 +62,23 @@ export const spinnerStyles = css `
   }
 
   [part="track"] {
+    fill: none;
     stroke: var(--dads-spinner-track-color);
+    stroke-width: 4;
+  }
+
+  [part="border"] {
+    fill: none;
+    stroke: var(--dads-spinner-indicator-color);
+    stroke-width: 1;
   }
 
   [part="indicator"] {
     stroke: var(--dads-spinner-indicator-color);
-    stroke-dasharray: 125.66;
-    stroke-dashoffset: 113;
-    animation: spinner-dash 1.4s ease-in-out infinite;
+    stroke-dasharray: 31.42 125.66;
+    stroke-dashoffset: 0;
+    fill: none;
+    animation: spinner-dash var(--dads-spinner-dash-duration) ease-in-out infinite;
   }
 
   [part="label"] {
@@ -81,7 +90,18 @@ export const spinnerStyles = css `
     color: var(--dads-spinner-label-color);
   }
 
-  :host(:not([label])) [part="label"] {
+  :host([speed="slow"]) {
+    --dads-spinner-rotate-duration: 3.2s;
+    --dads-spinner-dash-duration: 2.4s;
+  }
+
+  :host([speed="fast"]) {
+    --dads-spinner-rotate-duration: 1.6s;
+    --dads-spinner-dash-duration: 1.2s;
+  }
+
+  :host(:not([label])) [part="label"],
+  :host([label=""]) [part="label"] {
     display: none;
   }
 
@@ -95,17 +115,17 @@ export const spinnerStyles = css `
   }
 
   @keyframes spinner-dash {
-    0%, 25% {
-      stroke-dashoffset: 113;
-      transform: rotate(0deg);
+    0% {
+      stroke-dasharray: 1, 150;
+      stroke-dashoffset: 0;
     }
-    50%, 75% {
-      stroke-dashoffset: 30;
-      transform: rotate(45deg);
+    50% {
+      stroke-dasharray: 90, 150;
+      stroke-dashoffset: -35;
     }
     100% {
-      stroke-dashoffset: 113;
-      transform: rotate(360deg);
+      stroke-dasharray: 1, 150;
+      stroke-dashoffset: -125;
     }
   }
 
@@ -116,12 +136,17 @@ export const spinnerStyles = css `
 
     [part="indicator"] {
       animation: none;
-      stroke-dashoffset: 60;
+      stroke-dasharray: 31.42 125.66;
+      stroke-dashoffset: 0;
     }
   }
 
   @media (forced-colors: active) {
     [part="track"] {
+      stroke: CanvasText;
+    }
+
+    [part="border"] {
       stroke: CanvasText;
     }
 
@@ -131,6 +156,7 @@ export const spinnerStyles = css `
 
     [part="underlay"] {
       border-color: CanvasText;
+      background: Canvas;
     }
   }
 `;

--- a/vendor-runtime/src/components/spinner/spinner-tokens.js
+++ b/vendor-runtime/src/components/spinner/spinner-tokens.js
@@ -13,6 +13,8 @@ const spinnerSemanticTokensText = `
     --spinner-label-color: var(--color-neutral-solid-gray-900, #1a1a1a);
     --spinner-underlay-bg: var(--color-neutral-white, white);
     --spinner-underlay-border: var(--color-neutral-solid-gray-500, #7f7f7f);
+    --spinner-rotate-duration: 2.4s;
+    --spinner-dash-duration: 1.8s;
   }
 `;
 const spinnerLocalTokensText = `
@@ -22,6 +24,8 @@ const spinnerLocalTokensText = `
     --dads-spinner-label-color: var(--spinner-label-color);
     --dads-spinner-underlay-bg: var(--spinner-underlay-bg);
     --dads-spinner-underlay-border: var(--spinner-underlay-border);
+    --dads-spinner-rotate-duration: var(--spinner-rotate-duration);
+    --dads-spinner-dash-duration: var(--spinner-dash-duration);
   }
 `;
 export const spinnerTokens = css `${spinnerSemanticTokensText}${spinnerLocalTokensText}`;

--- a/vendor-runtime/src/components/spinner/spinner.js
+++ b/vendor-runtime/src/components/spinner/spinner.js
@@ -34,12 +34,14 @@ import { spinnerStyles } from './spinner-styles.js';
  * @csspart base - ルートコンテナ（role="progressbar"）
  * @csspart underlay - カード背景（underlay属性時に表示）
  * @csspart svg - SVGコンテナ
- * @csspart track - トラック円（背景）
+ * @csspart track - トラックリング（背景ドーナツ）
+ * @csspart border - 外周ボーダーライン
  * @csspart indicator - インジケーター円（アニメーション）
  * @csspart label - ラベルテキスト
  *
  * @attr {'sm' | 'lg'} size - サイズ（sm: 24px, lg: 48px）
  * @attr {'stacked' | 'inlined'} composition - レイアウト方向
+ * @attr {'slow' | 'normal' | 'fast'} speed - アニメーション速度
  * @attr {boolean} underlay - カード背景表示
  * @attr {string} label - 表示ラベル兼アクセシブル名
  *
@@ -48,6 +50,8 @@ import { spinnerStyles } from './spinner-styles.js';
  * @cssprop --dads-spinner-label-color - ラベルテキスト色
  * @cssprop --dads-spinner-underlay-bg - アンダーレイ背景色
  * @cssprop --dads-spinner-underlay-border - アンダーレイ枠線色
+ * @cssprop --dads-spinner-rotate-duration - 回転アニメーション速度
+ * @cssprop --dads-spinner-dash-duration - ダッシュアニメーション速度
  *
  * @example
  * ```html
@@ -69,6 +73,10 @@ export class DadsSpinner extends TypographyWebComponent {
         __classPrivateFieldSet(this, _DadsSpinner_labelEl, this.shadowRoot?.querySelector('[part="label"]') ?? null, "f");
         __classPrivateFieldGet(this, _DadsSpinner_instances, "m", _DadsSpinner_setDefaultAttributes).call(this);
         __classPrivateFieldGet(this, _DadsSpinner_instances, "m", _DadsSpinner_syncLabel).call(this);
+        const labelValue = this.getAttribute('label');
+        if (!labelValue || labelValue.length === 0) {
+            console.warn('[dads-spinner] label属性が未指定です。スクリーンリーダーのために label 属性を設定してください。');
+        }
     }
     labelChanged() {
         __classPrivateFieldGet(this, _DadsSpinner_instances, "m", _DadsSpinner_syncLabel).call(this);
@@ -80,6 +88,9 @@ _DadsSpinner_base = new WeakMap(), _DadsSpinner_labelEl = new WeakMap(), _DadsSp
     }
     if (!this.hasAttribute('composition')) {
         this.setAttribute('composition', 'stacked');
+    }
+    if (!this.hasAttribute('speed')) {
+        this.setAttribute('speed', 'normal');
     }
 }, _DadsSpinner_syncLabel = function _DadsSpinner_syncLabel() {
     if (!__classPrivateFieldGet(this, _DadsSpinner_base, "f") || !__classPrivateFieldGet(this, _DadsSpinner_labelEl, "f"))
@@ -101,12 +112,12 @@ DadsSpinner.definition = {
       <div part="base" role="progressbar">
         <div part="underlay" aria-hidden="true"></div>
         <svg part="svg" viewBox="0 0 48 48" aria-hidden="true" focusable="false">
-          <circle part="track" cx="24" cy="24" r="20"
-                  fill="none" stroke-width="4" />
+          <circle part="track" cx="24" cy="24" r="20" />
+          <circle part="border" cx="24" cy="24" r="22" />
           <circle part="indicator" cx="24" cy="24" r="20"
                   fill="none" stroke-width="4"
                   stroke-linecap="round"
-                  stroke-dasharray="125.66" />
+                  stroke-dasharray="31.42 125.66" />
         </svg>
         <span part="label"></span>
       </div>
@@ -120,6 +131,7 @@ DadsSpinner.definition = {
     attributes: [
         PropertyAttr('size'),
         PropertyAttr('composition'),
+        PropertyAttr('speed'),
         BooleanAttr('underlay'),
         PropertyAttr('label'),
     ],

--- a/vendor-runtime/src/components/tab/tab-styles.js
+++ b/vendor-runtime/src/components/tab/tab-styles.js
@@ -80,6 +80,7 @@ export const tabStyles = css `
 
   [part~="tab"]:focus-visible {
     z-index: 3;
+    border-radius: var(--dads-tab-focus-border-radius);
   }
 
   /* DADSフォーカスリングは維持しつつ、タブ面は塗りつぶさない */
@@ -148,9 +149,6 @@ export const tabStyles = css `
     [part~="tab"]:not([aria-selected="true"]):not([aria-disabled="true"]):hover {
       --_dads-tab-background: var(--dads-tab-background-hover);
       --_dads-tab-label-decoration: underline;
-    }
-
-    [part~="tab"]:not([aria-selected="true"]):not([aria-disabled="true"]):hover {
       --_dads-tab-indicator-color: var(--dads-tab-border-color);
     }
   }
@@ -168,6 +166,13 @@ export const tabStyles = css `
 
   ::slotted([part~="tabpanel"][hidden]) {
     display: none;
+  }
+
+  ::slotted([part~="tabpanel"]:focus-visible) {
+    outline: var(--dads-focus-outline-width) solid var(--dads-focus-outline-color);
+    outline-offset: var(--dads-focus-outline-offset);
+    box-shadow: 0 0 0 var(--dads-focus-ring-width) var(--dads-focus-ring-color);
+    border-radius: var(--dads-tab-focus-border-radius);
   }
 
   :host([orientation="bottom"]) [part="base"] {

--- a/vendor-runtime/src/components/tab/tab-tokens.js
+++ b/vendor-runtime/src/components/tab/tab-tokens.js
@@ -24,6 +24,7 @@ const tabSemanticTokensText = `
     /* Focus */
     --tab-focus-outline-color: var(--color-neutral-black, #000000);
     --tab-focus-ring-color: var(--color-primitive-yellow-300, #ffd43d);
+    --tab-focus-border-radius: calc(4 / 16 * 1rem);
 
     /* ========== Layout ========== */
     --tab-indicator-thickness: calc(6 / 16 * 1rem);
@@ -58,6 +59,7 @@ const tabLocalTokensText = `
     --dads-tab-indicator-height: var(--tab-indicator-thickness);
     --dads-tab-focus-outline-color: var(--tab-focus-outline-color);
     --dads-tab-focus-ring-color: var(--tab-focus-ring-color);
+    --dads-tab-focus-border-radius: var(--tab-focus-border-radius);
   }
 `;
 export const tabSemanticTokens = css `${tabSemanticTokensText}`;

--- a/vendor-runtime/src/components/tab/tab.js
+++ b/vendor-runtime/src/components/tab/tab.js
@@ -15,7 +15,7 @@ var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (
     if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
     return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
 };
-var _DadsTab_instances, _DadsTab_tablist, _DadsTab_slot, _DadsTab_tabs, _DadsTab_panels, _DadsTab_childObserver, _DadsTab_layoutObserver, _DadsTab_idCounter, _DadsTab_lastTablistBlockSize, _DadsTab_handleSlotChange, _DadsTab_handleChildMutation, _DadsTab_generateId, _DadsTab_getPanelChildren, _DadsTab_syncTabs, _DadsTab_syncAriaOrientation, _DadsTab_syncPanelMinBlockSize, _DadsTab_syncSelection, _DadsTab_getEnabledTabs, _DadsTab_handleTabClick, _DadsTab_handleKeyDown, _DadsTab_selectTab;
+var _DadsTab_instances, _DadsTab_tablist, _DadsTab_slot, _DadsTab_tabs, _DadsTab_panels, _DadsTab_childObserver, _DadsTab_layoutObserver, _DadsTab_idCounter, _DadsTab_lastTablistBlockSize, _DadsTab_handleSlotChange, _DadsTab_handleChildMutation, _DadsTab_generateId, _DadsTab_getPanelChildren, _DadsTab_getSelectedIndex, _DadsTab_syncTabs, _DadsTab_syncAriaOrientation, _DadsTab_syncPanelMinBlockSize, _DadsTab_syncSelection, _DadsTab_getEnabledTabs, _DadsTab_handleTabClick, _DadsTab_handleKeyDown, _DadsTab_focusActivePanel, _DadsTab_activateTab, _DadsTab_selectTab;
 import { html, PropertyAttr, Keys, ElementSelection, Orientation, } from '../../core/web-components.js';
 import { TypographyWebComponent } from '../../core/typography/typography-web-component.js';
 import { applyDADSTokens } from '../../styles/design-tokens/index.js';
@@ -24,6 +24,14 @@ import { applyDADSFocusStyles } from '../../styles/mixins/focus-styles-official.
 import { withReset } from '../../styles/reset-css.js';
 import { tabTokens } from './tab-tokens.js';
 import { tabStyles } from './tab-styles.js';
+const navigationKeys = new Set([
+    Keys.arrowUp,
+    Keys.arrowDown,
+    Keys.arrowLeft,
+    Keys.arrowRight,
+    Keys.home,
+    Keys.end,
+]);
 function normalizeOrientation(v) {
     if (v === 'bottom' || v === 'left' || v === 'right')
         return v;
@@ -67,6 +75,7 @@ function isHorizontalOrientation(orientation) {
  * @cssprop --dads-tab-indicator-height - インジケーター高さ
  * @cssprop --dads-tab-focus-outline-color - フォーカスアウトライン色
  * @cssprop --dads-tab-focus-ring-color - フォーカスリング色
+ * @cssprop --dads-tab-focus-border-radius - フォーカスリングの角丸
  *
  * @fires dads-tab-change - タブ選択変更時（detail: { selectedIndex: number, previousIndex: number }）
  *
@@ -139,27 +148,27 @@ export class DadsTab extends TypographyWebComponent {
         });
         _DadsTab_handleKeyDown.set(this, (event) => {
             const currentTab = event.currentTarget;
-            if (currentTab.getAttribute('aria-disabled') === 'true' &&
-                event.key !== Keys.arrowUp &&
-                event.key !== Keys.arrowDown &&
-                event.key !== Keys.arrowLeft &&
-                event.key !== Keys.arrowRight &&
-                event.key !== Keys.home &&
-                event.key !== Keys.end) {
+            const isDisabled = currentTab.getAttribute('aria-disabled') === 'true';
+            if (isDisabled && !navigationKeys.has(event.key))
                 return;
-            }
             const mode = normalizeActivationMode(this.getAttribute('activation-mode'));
             const orientation = normalizeOrientation(this.getAttribute('orientation'));
             const ariaOrientation = isHorizontalOrientation(orientation)
                 ? Orientation.horizontal
                 : Orientation.vertical;
-            // APG: manual モードでは Enter/Space で選択確定。フォーカスは tab に留める。
-            if (mode === 'manual' && (event.key === Keys.enter || event.key === Keys.space)) {
+            // Enter: タブパネルへフォーカスを移す（manual モードでは先に選択確定）
+            if (event.key === Keys.enter) {
                 event.preventDefault();
-                const index = __classPrivateFieldGet(this, _DadsTab_tabs, "f").indexOf(currentTab);
-                if (index >= 0 && currentTab.getAttribute('aria-disabled') !== 'true') {
-                    __classPrivateFieldGet(this, _DadsTab_instances, "m", _DadsTab_selectTab).call(this, index);
+                if (mode === 'manual') {
+                    __classPrivateFieldGet(this, _DadsTab_instances, "m", _DadsTab_activateTab).call(this, currentTab);
                 }
+                __classPrivateFieldGet(this, _DadsTab_instances, "m", _DadsTab_focusActivePanel).call(this);
+                return;
+            }
+            // Space: manual モードでは選択確定（フォーカスはタブに留まる）
+            if (mode === 'manual' && event.key === Keys.space) {
+                event.preventDefault();
+                __classPrivateFieldGet(this, _DadsTab_instances, "m", _DadsTab_activateTab).call(this, currentTab);
                 return;
             }
             const enabledTabs = __classPrivateFieldGet(this, _DadsTab_instances, "m", _DadsTab_getEnabledTabs).call(this);
@@ -169,10 +178,7 @@ export class DadsTab extends TypographyWebComponent {
             selection.processKey(event, (target) => {
                 target.focus();
                 if (mode === 'auto') {
-                    const index = __classPrivateFieldGet(this, _DadsTab_tabs, "f").indexOf(target);
-                    if (index >= 0) {
-                        __classPrivateFieldGet(this, _DadsTab_instances, "m", _DadsTab_selectTab).call(this, index);
-                    }
+                    __classPrivateFieldGet(this, _DadsTab_instances, "m", _DadsTab_activateTab).call(this, target);
                 }
             }, {
                 orientation: ariaOrientation,
@@ -251,6 +257,8 @@ _DadsTab_tablist = new WeakMap(), _DadsTab_slot = new WeakMap(), _DadsTab_tabs =
         children.push(child);
     }
     return children;
+}, _DadsTab_getSelectedIndex = function _DadsTab_getSelectedIndex() {
+    return Math.max(0, parseInt(this.getAttribute('selected-index') ?? '0', 10) || 0);
 }, _DadsTab_syncTabs = function _DadsTab_syncTabs() {
     const tablist = __classPrivateFieldGet(this, _DadsTab_tablist, "f");
     if (!tablist)
@@ -276,6 +284,7 @@ _DadsTab_tablist = new WeakMap(), _DadsTab_slot = new WeakMap(), _DadsTab_tabs =
         tab.setAttribute('role', 'tab');
         tab.setAttribute('id', tabId);
         tab.setAttribute('aria-controls', child.id);
+        tab.setAttribute('tabindex', '0');
         tab.type = 'button';
         tab.addEventListener('click', __classPrivateFieldGet(this, _DadsTab_handleTabClick, "f"));
         tab.addEventListener('keydown', __classPrivateFieldGet(this, _DadsTab_handleKeyDown, "f"));
@@ -293,7 +302,7 @@ _DadsTab_tablist = new WeakMap(), _DadsTab_slot = new WeakMap(), _DadsTab_tabs =
         child.setAttribute('role', 'tabpanel');
         child.setAttribute('part', 'tabpanel');
         child.setAttribute('aria-labelledby', tabId);
-        child.setAttribute('tabindex', '0');
+        child.setAttribute('tabindex', '-1');
         tablist.appendChild(tab);
         __classPrivateFieldGet(this, _DadsTab_tabs, "f").push(tab);
         __classPrivateFieldGet(this, _DadsTab_panels, "f").push(child);
@@ -328,19 +337,15 @@ _DadsTab_tablist = new WeakMap(), _DadsTab_slot = new WeakMap(), _DadsTab_tabs =
     __classPrivateFieldSet(this, _DadsTab_lastTablistBlockSize, nextValue, "f");
     this.style.setProperty('--_dads-tab-tablist-block-size', nextValue);
 }, _DadsTab_syncSelection = function _DadsTab_syncSelection() {
-    const index = Math.max(0, parseInt(this.getAttribute('selected-index') ?? '0', 10) || 0);
-    const clampedIndex = Math.min(index, __classPrivateFieldGet(this, _DadsTab_tabs, "f").length - 1);
+    const clampedIndex = Math.min(__classPrivateFieldGet(this, _DadsTab_instances, "m", _DadsTab_getSelectedIndex).call(this), __classPrivateFieldGet(this, _DadsTab_tabs, "f").length - 1);
     for (let i = 0; i < __classPrivateFieldGet(this, _DadsTab_tabs, "f").length; i++) {
-        const tab = __classPrivateFieldGet(this, _DadsTab_tabs, "f")[i];
-        const panel = __classPrivateFieldGet(this, _DadsTab_panels, "f")[i];
         const isSelected = i === clampedIndex;
-        tab.setAttribute('aria-selected', String(isSelected));
-        tab.setAttribute('tabindex', isSelected ? '0' : '-1');
+        __classPrivateFieldGet(this, _DadsTab_tabs, "f")[i].setAttribute('aria-selected', String(isSelected));
         if (isSelected) {
-            panel.removeAttribute('hidden');
+            __classPrivateFieldGet(this, _DadsTab_panels, "f")[i].removeAttribute('hidden');
         }
         else {
-            panel.setAttribute('hidden', '');
+            __classPrivateFieldGet(this, _DadsTab_panels, "f")[i].setAttribute('hidden', '');
         }
     }
 }, _DadsTab_getEnabledTabs = function _DadsTab_getEnabledTabs() {
@@ -351,8 +356,20 @@ _DadsTab_tablist = new WeakMap(), _DadsTab_slot = new WeakMap(), _DadsTab_tabs =
         enabled.push(tab);
     }
     return enabled;
+}, _DadsTab_focusActivePanel = function _DadsTab_focusActivePanel() {
+    const clampedIndex = Math.min(__classPrivateFieldGet(this, _DadsTab_instances, "m", _DadsTab_getSelectedIndex).call(this), __classPrivateFieldGet(this, _DadsTab_panels, "f").length - 1);
+    if (clampedIndex >= 0 && __classPrivateFieldGet(this, _DadsTab_panels, "f")[clampedIndex]) {
+        __classPrivateFieldGet(this, _DadsTab_panels, "f")[clampedIndex].focus();
+    }
+}, _DadsTab_activateTab = function _DadsTab_activateTab(tab) {
+    if (tab.getAttribute('aria-disabled') === 'true')
+        return;
+    const index = __classPrivateFieldGet(this, _DadsTab_tabs, "f").indexOf(tab);
+    if (index >= 0) {
+        __classPrivateFieldGet(this, _DadsTab_instances, "m", _DadsTab_selectTab).call(this, index);
+    }
 }, _DadsTab_selectTab = function _DadsTab_selectTab(index) {
-    const previousIndex = parseInt(this.getAttribute('selected-index') ?? '0', 10) || 0;
+    const previousIndex = __classPrivateFieldGet(this, _DadsTab_instances, "m", _DadsTab_getSelectedIndex).call(this);
     if (index === previousIndex)
         return;
     this.setAttribute('selected-index', String(index));

--- a/vendor-runtime/src/figma-export/figma-post-process.js
+++ b/vendor-runtime/src/figma-export/figma-post-process.js
@@ -1,0 +1,303 @@
+/**
+ * @module figma-export/figma-post-process
+ * Figma HTML-to-Design 変換器で正しく変換されない CSS プロパティを
+ * 変換可能な形式に書き換える後処理ユーティリティ。
+ *
+ * 戦略: 計算済みスタイルが大量にある既存要素のスタイル修正は避ける。
+ * Figma パーサーは競合するプロパティを正しく解決できないため、
+ * 最小限のスタイルだけを持つ新規 DOM 要素を挿入して視覚表現を再現する。
+ *
+ * 対象:
+ * - text-decoration: underline → 新規 div (background-color) で下線を再現
+ * - outline + box-shadow → 新規 div (background-color) でフォーカスリングを再現
+ */
+/**
+ * フラット化済み HTML 要素に Figma 変換向けの後処理を適用する。
+ *
+ * @param el - flattenElementToLightDom() の出力
+ * @param state - 状態ラベル
+ * @returns 後処理済みの HTML 要素（元の要素が変更される場合あり）
+ */
+export function postProcessForFigma(el, state) {
+    // height 関連プロパティを除去（テキスト折り返しによるオーバーフロー防止）
+    relaxFixedHeights(el);
+    // text-decoration: underline → 下線用 div を挿入
+    insertUnderlineElements(el);
+    // focus-visible 状態: outline + box-shadow → フォーカスリング用 div を挿入
+    if (state === 'focus-visible') {
+        return insertFocusRingElements(el);
+    }
+    return el;
+}
+// ─── 画像の data URI 変換 ───
+/**
+ * 対象要素内の全 <img> を canvas 経由で data URI に変換する。
+ * flattenElementToLightDom() の前に呼び出す（ブラウザコンテキスト必須）。
+ */
+export function convertImagesToDataUri(root) {
+    const images = root.querySelectorAll('img');
+    for (let i = 0; i < images.length; i++) {
+        const img = images[i];
+        if (!img.complete || img.naturalWidth === 0)
+            continue;
+        // 既に data URI の場合はスキップ
+        if (img.src.startsWith('data:'))
+            continue;
+        try {
+            const canvas = document.createElement('canvas');
+            canvas.width = img.naturalWidth;
+            canvas.height = img.naturalHeight;
+            const ctx = canvas.getContext('2d');
+            if (!ctx)
+                continue;
+            ctx.drawImage(img, 0, 0);
+            const dataUri = canvas.toDataURL('image/png');
+            img.src = dataUri;
+        }
+        catch {
+            // CORS エラー等は無視（画像が取れないだけ）
+        }
+    }
+}
+// ─── height → min-height 変換 ───
+/** replaced 要素: height を維持する必要がある */
+const REPLACED_TAGS = new Set(['img', 'svg', 'video', 'canvas', 'input', 'textarea', 'select', 'iframe']);
+/**
+ * 非 replaced 要素から height / block-size を完全除去する。
+ *
+ * Figma HTML-to-Design は内部でHTMLを再レンダリングするため、
+ * 固定 height があるとテキスト折り返し時にコンテナが拡張されない。
+ * height を除去すれば、Figmaの内部レンダラーがコンテンツベースで
+ * 高さを計算し、テキスト重なりが解消される。
+ *
+ * max-height / min-height も除去して、レンダラーに自由な計算を委ねる。
+ */
+function relaxFixedHeights(el) {
+    const tag = el.tagName.toLowerCase();
+    // replaced 要素、Figma 後処理要素はスキップ
+    if (REPLACED_TAGS.has(tag) || el.hasAttribute('data-figma-ring') || el.hasAttribute('data-figma-underline')) {
+        return;
+    }
+    // height 関連プロパティを全て除去
+    for (const prop of ['height', 'block-size', 'min-height', 'min-block-size', 'max-height', 'max-block-size']) {
+        el.style.removeProperty(prop);
+    }
+    // 子要素を再帰処理
+    for (let i = 0; i < el.children.length; i++) {
+        const child = el.children[i];
+        if (child instanceof HTMLElement) {
+            relaxFixedHeights(child);
+        }
+    }
+}
+// ─── text-decoration: underline → background-color div ───
+/**
+ * ツリー内で text-decoration: underline を持つ要素を探し、
+ * テキスト直下に下線用の div を挿入する。
+ *
+ * 既存要素のスタイルは変更しない。Figma が確実に変換できる
+ * background-color + height の新規要素で下線を再現する。
+ */
+function insertUnderlineElements(el) {
+    processUnderlineRecursive(el);
+}
+function processUnderlineRecursive(el) {
+    const td = el.style.getPropertyValue('text-decoration');
+    if (td.includes('underline')) {
+        // 下線色を抽出
+        const colorMatch = td.match(/rgba?\([^)]+\)/);
+        const color = colorMatch ? colorMatch[0] : 'rgb(255, 255, 255)';
+        // text-decoration を none に
+        el.style.setProperty('text-decoration', 'none');
+        // テキストを含む最も内側の要素を探す
+        const textContainer = findTextContainer(el);
+        if (textContainer) {
+            const doc = el.ownerDocument;
+            // 下線用 div: background-color + height のみ（Figma 確実対応）
+            const underlineDiv = doc.createElement('div');
+            underlineDiv.setAttribute('data-figma-underline', 'true');
+            underlineDiv.style.cssText = [
+                `background-color: ${color}`,
+                'height: 1px',
+                'width: 100%',
+                'margin-top: 2px',
+            ].join('; ');
+            // テキスト要素の直後に挿入
+            const parent = textContainer.parentElement;
+            if (parent && parent !== el) {
+                // テキスト要素が子要素の場合、その後に挿入
+                parent.insertBefore(underlineDiv, textContainer.nextSibling);
+            }
+            else {
+                // テキスト要素がルートの場合、末尾に追加
+                textContainer.appendChild(underlineDiv);
+            }
+        }
+    }
+    // 子要素を再帰処理
+    for (let i = 0; i < el.children.length; i++) {
+        const child = el.children[i];
+        if (child instanceof HTMLElement && !child.hasAttribute('data-figma-underline')) {
+            processUnderlineRecursive(child);
+        }
+    }
+}
+/**
+ * テキストコンテンツを含む最も内側の要素を返す。
+ */
+function findTextContainer(el) {
+    for (let i = 0; i < el.childNodes.length; i++) {
+        const child = el.childNodes[i];
+        if (child.nodeType === Node.TEXT_NODE && child.textContent?.trim()) {
+            return el;
+        }
+    }
+    for (let i = 0; i < el.children.length; i++) {
+        const child = el.children[i];
+        if (child instanceof HTMLElement) {
+            const found = findTextContainer(child);
+            if (found)
+                return found;
+        }
+    }
+    return null;
+}
+// ─── outline + box-shadow → background-color div でフォーカスリング再現 ───
+/**
+ * focus-visible 状態のフォーカスリングを Figma 対応形式に変換する。
+ *
+ * outline と box-shadow (spread-only) を検出し、
+ * background-color を持つラッパー div で視覚的にリングを再現する。
+ *
+ * 構造:
+ *   <div data-figma-ring="outer" style="background-color: black; padding: 4px; ...">
+ *     <div data-figma-ring="inner" style="background-color: yellow; padding: 2px; ...">
+ *       <button style="...（outline/box-shadow除去）...">
+ *     </div>
+ *   </div>
+ */
+function insertFocusRingElements(el) {
+    // outline を持つ要素を探す
+    const target = findOutlineElement(el);
+    if (!target)
+        return el;
+    const outlineWidth = target.style.getPropertyValue('outline-width');
+    const outlineColor = target.style.getPropertyValue('outline-color');
+    const outlineOffset = target.style.getPropertyValue('outline-offset');
+    const borderRadius = target.style.getPropertyValue('border-radius');
+    if (!outlineWidth || outlineWidth === '0px')
+        return el;
+    // box-shadow から spread-only shadow を検出
+    const boxShadow = target.style.getPropertyValue('box-shadow');
+    const spreadShadow = parseSpreadOnlyShadow(boxShadow);
+    const doc = target.ownerDocument;
+    // 元要素から outline と box-shadow を除去
+    target.style.setProperty('outline', 'none');
+    if (spreadShadow) {
+        target.style.setProperty('box-shadow', 'none');
+    }
+    // 外側リング: outline を background-color + padding で再現
+    const outerRing = doc.createElement('div');
+    outerRing.setAttribute('data-figma-ring', 'outer');
+    outerRing.style.cssText = [
+        `background-color: ${outlineColor}`,
+        `padding: ${outlineWidth}`,
+        'display: inline-block',
+        borderRadius ? `border-radius: ${addPx(borderRadius, parsePx(outlineWidth) + parsePx(outlineOffset))}` : '',
+    ].filter(Boolean).join('; ');
+    if (spreadShadow) {
+        // 中間リング: box-shadow spread を background-color + padding で再現
+        const innerRing = doc.createElement('div');
+        innerRing.setAttribute('data-figma-ring', 'inner');
+        innerRing.style.cssText = [
+            `background-color: ${spreadShadow.color}`,
+            `padding: ${spreadShadow.spread}`,
+            'display: inline-block',
+            borderRadius ? `border-radius: ${addPx(borderRadius, parsePx(spreadShadow.spread))}` : '',
+        ].filter(Boolean).join('; ');
+        // outline-offset を gap として再現
+        if (outlineOffset && outlineOffset !== '0px') {
+            const gapDiv = doc.createElement('div');
+            gapDiv.setAttribute('data-figma-ring', 'gap');
+            gapDiv.style.cssText = [
+                'background-color: transparent',
+                `padding: ${outlineOffset}`,
+                'display: inline-block',
+                borderRadius ? `border-radius: ${addPx(borderRadius, parsePx(outlineOffset))}` : '',
+            ].filter(Boolean).join('; ');
+            // target を DOM ツリーから差し替え
+            const placeholder = doc.createComment('figma-ring');
+            target.parentElement?.insertBefore(placeholder, target);
+            gapDiv.appendChild(target);
+            innerRing.appendChild(gapDiv);
+            outerRing.appendChild(innerRing);
+            placeholder.parentNode?.replaceChild(outerRing, placeholder);
+        }
+        else {
+            const placeholder = doc.createComment('figma-ring');
+            target.parentElement?.insertBefore(placeholder, target);
+            innerRing.appendChild(target);
+            outerRing.appendChild(innerRing);
+            placeholder.parentNode?.replaceChild(outerRing, placeholder);
+        }
+    }
+    else {
+        const placeholder = doc.createComment('figma-ring');
+        target.parentElement?.insertBefore(placeholder, target);
+        outerRing.appendChild(target);
+        placeholder.parentNode?.replaceChild(outerRing, placeholder);
+    }
+    return el;
+}
+/**
+ * ツリー内で outline-style が none 以外の要素を探す
+ */
+function findOutlineElement(el) {
+    const style = el.style.getPropertyValue('outline-style');
+    if (style && style !== 'none')
+        return el;
+    for (let i = 0; i < el.children.length; i++) {
+        const child = el.children[i];
+        if (child instanceof HTMLElement) {
+            const found = findOutlineElement(child);
+            if (found)
+                return found;
+        }
+    }
+    return null;
+}
+/**
+ * box-shadow 値から spread-only shadow（x=0, y=0, blur=0）を検出
+ * 例: "rgb(255, 212, 61) 0px 0px 0px 2px" → { color, spread }
+ */
+function parseSpreadOnlyShadow(value) {
+    if (!value || value === 'none')
+        return null;
+    const colorMatch = value.match(/^(rgba?\([^)]+\))\s+/);
+    if (!colorMatch)
+        return null;
+    const color = colorMatch[1];
+    const rest = value.slice(colorMatch[0].length).trim();
+    const parts = rest.split(/\s+/);
+    if (parts.length < 4)
+        return null;
+    const [offsetX, offsetY, blur, spread] = parts;
+    if (offsetX === '0px' && offsetY === '0px' && blur === '0px' && spread !== '0px') {
+        return { color, spread };
+    }
+    return null;
+}
+/**
+ * "8px" のような CSS px 値をパースして数値を返す
+ */
+function parsePx(value) {
+    const match = value.match(/^(-?\d+(?:\.\d+)?)px$/);
+    return match ? Number(match[1]) : 0;
+}
+/**
+ * border-radius の px 値に加算する
+ */
+function addPx(radius, add) {
+    const base = parsePx(radius);
+    return `${base + add}px`;
+}

--- a/vendor-runtime/src/figma-export/flatten.js
+++ b/vendor-runtime/src/figma-export/flatten.js
@@ -1,0 +1,301 @@
+/**
+ * @module figma-export/flatten
+ * Shadow DOM を展開して light DOM に変換し、computed style をインライン化するユーティリティ。
+ * Figma 取り込み用 HTML 生成で使用。
+ */
+const SVG_NS = 'http://www.w3.org/2000/svg';
+/**
+ * 属性名がパターンにマッチするかチェック
+ */
+function matchesAttributePattern(attrName, patterns) {
+    for (const pattern of patterns) {
+        if (pattern.endsWith('*')) {
+            const prefix = pattern.slice(0, -1);
+            if (attrName.startsWith(prefix))
+                return true;
+        }
+        else if (attrName === pattern) {
+            return true;
+        }
+    }
+    return false;
+}
+/**
+ * 擬似要素（::before / ::after）の computed style を取得し、
+ * content が有効なら <span data-pseudo="..."> を生成して返す。
+ */
+function createPseudoElement(src, pseudo, doc) {
+    const cs = getComputedStyle(src, pseudo);
+    const content = cs.getPropertyValue('content');
+    // content が none / normal / 空なら生成しない
+    if (!content || content === 'none' || content === 'normal' || content === '""' || content === "''") {
+        return null;
+    }
+    const span = doc.createElement('span');
+    span.setAttribute('data-pseudo', pseudo === '::before' ? 'before' : 'after');
+    // content 値からテキストを抽出（引用符を除去）
+    const textContent = content.replace(/^["']|["']$/g, '');
+    if (textContent) {
+        span.textContent = textContent;
+    }
+    // 擬似要素のスタイルをインライン化
+    inlineComputedStyles(span, cs);
+    return span;
+}
+/**
+ * getComputedStyle の結果を要素の style 属性にインライン化
+ */
+function inlineComputedStyles(dst, cs) {
+    for (const prop of cs) {
+        const value = cs.getPropertyValue(prop);
+        if (value) {
+            dst.style.setProperty(prop, value, cs.getPropertyPriority(prop));
+        }
+    }
+}
+/**
+ * 要素の保持すべき属性をコピー
+ */
+function copyKeptAttributes(src, dst, patterns) {
+    for (let i = 0; i < src.attributes.length; i++) {
+        const attr = src.attributes[i];
+        if (attr.name === 'style')
+            continue; // style は別途処理
+        if (attr.name === 'class')
+            continue; // class は不要
+        if (matchesAttributePattern(attr.name, patterns)) {
+            dst.setAttribute(attr.name, attr.value);
+        }
+    }
+}
+/**
+ * keepAttributes とは独立に、HTML として機能するために必要な属性をコピー。
+ * keepAttributes のパターンマッチとは別枠で常にコピーする。
+ */
+const ESSENTIAL_HTML_ATTRS = ['type', 'href', 'target', 'rel', 'download', 'id', 'name', 'tabindex', 'disabled'];
+function copyEssentialHtmlAttributes(src, dst) {
+    for (const attrName of ESSENTIAL_HTML_ATTRS) {
+        if (src.hasAttribute(attrName) && !dst.hasAttribute(attrName)) {
+            dst.setAttribute(attrName, src.getAttribute(attrName) ?? '');
+        }
+    }
+}
+/**
+ * SVG 要素かどうかを判定
+ */
+function isSVGElement(el) {
+    return el.namespaceURI === SVG_NS;
+}
+/**
+ * 要素がカスタム要素（ハイフン付きタグ名）かどうかを判定
+ */
+function isCustomElement(el) {
+    return el.tagName.includes('-');
+}
+/**
+ * ノードの子ノードを再帰的にフラット化して dst に追加
+ */
+function flattenChildren(children, dst, opts, doc) {
+    for (const child of children) {
+        const flattened = flattenNode(child, opts, doc);
+        if (flattened) {
+            dst.appendChild(flattened);
+        }
+    }
+}
+/**
+ * 単一ノードをフラット化
+ */
+function flattenNode(node, opts, doc) {
+    // テキストノードはそのままコピー
+    if (node.nodeType === Node.TEXT_NODE) {
+        return doc.createTextNode(node.textContent ?? '');
+    }
+    // コメントノードはスキップ
+    if (node.nodeType === Node.COMMENT_NODE) {
+        return null;
+    }
+    // 要素ノード以外はスキップ
+    if (!(node instanceof Element)) {
+        return null;
+    }
+    const el = node;
+    // <style> タグはスキップ（インライン化するため不要）
+    if (el.tagName.toLowerCase() === 'style') {
+        return null;
+    }
+    // dropDisplayNone: display が none の要素はスキップ
+    if (opts.dropDisplayNone) {
+        const cs = getComputedStyle(el);
+        if (cs.display === 'none') {
+            return null;
+        }
+    }
+    // <slot> 要素: assignedNodes を展開
+    if (el instanceof HTMLSlotElement) {
+        const assigned = el.assignedNodes({ flatten: true });
+        // slot の割り当てノードを DocumentFragment にまとめる
+        const frag = doc.createDocumentFragment();
+        for (const assignedNode of assigned) {
+            const flattened = flattenNode(assignedNode, opts, doc);
+            if (flattened) {
+                frag.appendChild(flattened);
+            }
+        }
+        return frag.childNodes.length > 0 ? frag : null;
+    }
+    // Shadow DOM を持つカスタム要素
+    if (el.shadowRoot) {
+        return flattenShadowHost(el, opts, doc);
+    }
+    // 通常のカスタム要素（Shadow DOM なし）→ div にフォールバック
+    if (isCustomElement(el)) {
+        const wrapper = doc.createElement('div');
+        wrapper.setAttribute('data-wcf-host', el.tagName.toLowerCase());
+        const cs = getComputedStyle(el);
+        if (opts.inlineAllComputed) {
+            inlineComputedStyles(wrapper, cs);
+        }
+        copyKeptAttributes(el, wrapper, opts.keepAttributes);
+        flattenChildren(el.childNodes, wrapper, opts, doc);
+        return wrapper;
+    }
+    // SVG 要素
+    if (isSVGElement(el)) {
+        return flattenSVGElement(el, opts, doc);
+    }
+    // 通常の HTML 要素
+    return flattenHTMLElement(el, opts, doc);
+}
+/**
+ * Shadow DOM ホスト要素をフラット化
+ */
+function flattenShadowHost(el, opts, doc) {
+    const wrapper = doc.createElement('div');
+    wrapper.setAttribute('data-wcf-host', el.tagName.toLowerCase());
+    // ホスト要素の computed style をインライン化
+    const cs = getComputedStyle(el);
+    if (opts.inlineAllComputed) {
+        inlineComputedStyles(wrapper, cs);
+    }
+    // 保持する属性をコピー
+    copyKeptAttributes(el, wrapper, opts.keepAttributes);
+    // shadowRoot の子ノードを再帰的にフラット化
+    const shadowRoot = el.shadowRoot;
+    if (shadowRoot) {
+        flattenChildren(shadowRoot.childNodes, wrapper, opts, doc);
+    }
+    return wrapper;
+}
+/**
+ * SVG 要素を再帰的にフラット化
+ */
+function flattenSVGElement(el, opts, doc) {
+    const tagName = el.tagName.toLowerCase();
+    const clone = doc.createElementNS(SVG_NS, tagName);
+    // SVG 属性をコピー（class 以外の全属性）
+    for (let i = 0; i < el.attributes.length; i++) {
+        const attr = el.attributes[i];
+        if (attr.name === 'class')
+            continue;
+        if (attr.namespaceURI) {
+            clone.setAttributeNS(attr.namespaceURI, attr.name, attr.value);
+        }
+        else {
+            clone.setAttribute(attr.name, attr.value);
+        }
+    }
+    // computed style をインライン化
+    if (opts.inlineAllComputed) {
+        const cs = getComputedStyle(el);
+        inlineComputedStyles(clone, cs);
+    }
+    // 子要素を再帰的に処理
+    for (const child of el.childNodes) {
+        if (child.nodeType === Node.TEXT_NODE) {
+            clone.appendChild(doc.createTextNode(child.textContent ?? ''));
+        }
+        else if (child instanceof SVGElement) {
+            clone.appendChild(flattenSVGElement(child, opts, doc));
+        }
+        else if (child instanceof Element) {
+            const flattened = flattenNode(child, opts, doc);
+            if (flattened)
+                clone.appendChild(flattened);
+        }
+    }
+    return clone;
+}
+/**
+ * 通常の HTML 要素をフラット化
+ */
+function flattenHTMLElement(el, opts, doc) {
+    const tagName = el.tagName.toLowerCase();
+    const clone = doc.createElement(tagName);
+    // 保持する属性をコピー（keepAttributes パターン + HTML 標準の必須属性）
+    copyKeptAttributes(el, clone, opts.keepAttributes);
+    copyEssentialHtmlAttributes(el, clone);
+    // computed style をインライン化
+    if (opts.inlineAllComputed) {
+        const cs = getComputedStyle(el);
+        inlineComputedStyles(clone, cs);
+    }
+    // ::before 擬似要素
+    const before = createPseudoElement(el, '::before', doc);
+    if (before) {
+        clone.appendChild(before);
+    }
+    // 子ノードを再帰処理
+    flattenChildren(el.childNodes, clone, opts, doc);
+    // ::after 擬似要素
+    const after = createPseudoElement(el, '::after', doc);
+    if (after) {
+        clone.appendChild(after);
+    }
+    return clone;
+}
+/**
+ * Shadow DOM を持つ Web Component ツリーを light DOM に変換し、
+ * computed style をインライン化する。
+ *
+ * @param root - 変換対象のルート要素（通常はカスタム要素）
+ * @param opts - オプション
+ * @returns フラット化された HTMLElement
+ */
+export function flattenElementToLightDom(root, opts) {
+    const resolved = {
+        dropDisplayNone: opts?.dropDisplayNone ?? true,
+        inlineAllComputed: opts?.inlineAllComputed ?? true,
+        keepAttributes: opts?.keepAttributes ?? ['aria-*', 'data-*', 'role', 'part'],
+    };
+    const doc = root.ownerDocument;
+    const result = flattenNode(root, resolved, doc);
+    if (result instanceof HTMLElement) {
+        return result;
+    }
+    // DocumentFragment などの場合は div でラップ
+    const wrapper = doc.createElement('div');
+    if (result) {
+        wrapper.appendChild(result);
+    }
+    return wrapper;
+}
+/**
+ * ノードを HTML 文字列にシリアライズ
+ */
+export function serializeNode(node) {
+    if (node.nodeType === Node.TEXT_NODE) {
+        return node.textContent ?? '';
+    }
+    if (node instanceof Element) {
+        return node.outerHTML;
+    }
+    if (node instanceof DocumentFragment) {
+        let html = '';
+        for (const child of node.childNodes) {
+            html += serializeNode(child);
+        }
+        return html;
+    }
+    return '';
+}


### PR DESCRIPTION
## Summary
- sync generated `vendor-runtime` output for button/loading-icon/progress-bar/spinner/tab updates
- add generated docs for `loading-icon`, `progress-bar`, `spinner`, `tab`
- include transpiled `vendor-runtime/src/figma-export/*`

## Scope
- `vendor-runtime/src/components/{button,loading-icon,progress-bar,spinner,tab}/*`
- `vendor-runtime/src/figma-export/*`
- `docs/components/{loading-icon,progress-bar,spinner,tab}.md`

## Verification
- `npm run -s vendor:check`
- `npm run -s wcf:docs:check`
